### PR TITLE
RNMT-1575 - Fix camera plugin crash due to NullPointerException

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -20,6 +20,9 @@
 -->
 # Release Notes
 
+### 2.3.2-OS (Apr 16, 2018)
+* [RNMT-1575] Fixed camera plugin to not crash when an invalid bitmap is present (and intent extras doesn't have info - NullPointerException)
+
 ### 2.3.1 (Dec 07, 2016)
 * [CB-12224](https://issues.apache.org/jira/browse/CB-12224) Updated version and RELEASENOTES.md for release 2.3.1
 * Fix missing license headers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "2.3.1.OS",
+  "version": "2.3.2-OS",
   "description": "Cordova Camera Plugin",
   "cordova": {
     "id": "cordova-plugin-camera",

--- a/plugin.xml
+++ b/plugin.xml
@@ -22,7 +22,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     id="cordova-plugin-camera"
-    version="2.3.1.OS">
+    version="2.3.2-OS">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -519,7 +519,17 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             if (bitmap == null) {
                 // Try to get the bitmap from intent.
-                bitmap = (Bitmap) intent.getExtras().get("data");
+                if (intent != null) {
+                    try {
+                        // getExtras can throw different exceptions
+                        Bundle extras = intent.getExtras();
+                        if (extras != null) {
+                            bitmap = (Bitmap) intent.getExtras().get("data");
+                        }
+                    } catch (Exception e) {
+                        // Don't let the exception bubble up, bitmap will be null (check below)
+                    }
+                }
             }
 
             // Double-check the bitmap.


### PR DESCRIPTION
Fixed camera plugin to not crash when an invalid bitmap is present (and intent extras doesn't have info - NullPointerException)