### PR TITLE
Added a preference to enable changing the Geolocation permissions message.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -175,8 +175,9 @@
              <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
          </config-file>
 
+         <preference name="GEOLOCATION_USAGE_DESCRIPTION" default=" " />
          <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
-             <string></string>
+             <string>$GEOLOCATION_USAGE_DESCRIPTION</string>
          </config-file>
 
      </platform>


### PR DESCRIPTION
This will allow developers to set the _NSLocationWhenInUseUsageDescription_ via Extensibility Configuration in Service Studio by setting the GEOLOCATION_USAGE_DESCRIPTION preference.