### PR TITLE
RNMT-3431 Fix WebView shift in iOS 13

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -729,7 +729,7 @@ static NSString* toBase64(NSData* data) {
 
 - (BOOL)prefersStatusBarHidden
 {
-    return YES;
+    return NO;
 }
 
 - (UIViewController*)childViewControllerForStatusBarHidden


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
As per https://github.com/apache/cordova-plugin-camera/issues/511 iOS 13 is causing a shift in both WebViews when returning from the camera viewfinder due to the status bar being hidden. Although https://github.com/apache/cordova-plugin-statusbar/issues/156 roots this issue in cordova-plugin-statusbar, this workaround is acceptable for two reasons: 

1. the only difference is the status bar icons are showing in the viewfinder (which is doubtful many will notice).
1. We can wait while upstream works on a proper fix.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
Fixes https://outsystemsrd.atlassian.net/browse/RNMT-3431

<!--- Why is this change required? What problem does it solve? -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
    - [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Manual tests.

## Screenshots (if appropriate)
<!--- E.g. before change & after change -->
![webview_shift](https://user-images.githubusercontent.com/996955/66998978-199a1100-f0cd-11e9-8266-160d85747a68.gif)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly