### PR TITLE
(android) fix: use provider prefix to avoid conflict with cordova-open plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -59,7 +59,7 @@
         <config-file target="AndroidManifest.xml" parent="application">
           <provider
               android:name="org.apache.cordova.camera.FileProvider"
-              android:authorities="${applicationId}.provider"
+              android:authorities="${applicationId}.camera.provider"
               android:exported="false"
               android:grantUriPermissions="true" >
               <meta-data

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -301,7 +301,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         // Specify file so that large image is captured and returned
         File photo = createCaptureFile(encodingType);
         this.imageUri = new CordovaUri(FileProvider.getUriForFile(cordova.getActivity(),
-                applicationId + ".provider",
+                applicationId + ".camera.provider",
                 photo));
         intent.putExtra(MediaStore.EXTRA_OUTPUT, imageUri.getCorrectUri());
         //We can write to this URI, this will hopefully allow us to write files to get to the next step
@@ -799,7 +799,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 try {
                     if (this.allowEdit) {
                         Uri tmpFile = FileProvider.getUriForFile(cordova.getActivity(),
-                                applicationId + ".provider",
+                                applicationId + ".camera.provider",
                                 createCaptureFile(this.encodingType));
                         performCrop(tmpFile, destType, intent);
                     } else {


### PR DESCRIPTION

In trying to find a solution to this problem, these changes have solved our problem. Please check if you can apply this change to the plugin.

Original Pull Request and explanation:
[Pull Request](https://github.com/apache/cordova-plugin-camera/pull/510)

Fix this case:
[Outsystems Case](https://www.outsystems.com/supportportal/case_show.aspx?caseid=2324473&)