### PR TITLE
Fix for SaveToPhotoAlbum Quality and Encoding implemented

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.2.0-OS4",
+  "version": "4.2.0-OS5",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="4.2.0-OS4">
+    version="4.2.0-OS5">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -442,6 +442,7 @@ static NSString* toBase64(NSData* data) {
     CDVPluginResult* result = nil;
     BOOL saveToPhotoAlbum = options.saveToPhotoAlbum;
     UIImage* image = nil;
+    NSData *imageData;
 
     switch (options.destinationType) {
         case DestinationTypeNativeUri:
@@ -475,7 +476,7 @@ static NSString* toBase64(NSData* data) {
             image = [self retrieveImage:info options:options];
             NSData* data = [self processImage:image info:info options:options];
             if (data) {
-
+                imageData = data;
                 NSString* extension = options.encodingType == EncodingTypePNG? @"png" : @"jpg";
                 NSString* filePath = [self tempFilePath:extension];
                 NSError* err = nil;
@@ -494,6 +495,7 @@ static NSString* toBase64(NSData* data) {
             image = [self retrieveImage:info options:options];
             NSData* data = [self processImage:image info:info options:options];
             if (data)  {
+                imageData = data;
                 result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:toBase64(data)];
             }
         }
@@ -504,7 +506,7 @@ static NSString* toBase64(NSData* data) {
 
     if (saveToPhotoAlbum && image) {
         ALAssetsLibrary* library = [ALAssetsLibrary new];
-        [library writeImageToSavedPhotosAlbum:image.CGImage orientation:(ALAssetOrientation)(image.imageOrientation) completionBlock:nil];
+        [library writeImageDataToSavedPhotosAlbum:imageData metadata:nil completionBlock:nil];
     }
 
     completion(result);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix for SaveToPhotoAlbum Quality and Encoding

When the camera the "Save to Gallery" option was enabled, the final picture saved in the gallery was not respecting the quality and encoding settings.
Fix made using the NSData processed image to save the picture.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->


<!--- Why is this change required? What problem does it solve? -->
Fix needed for releasing the plugin on Forge
 
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
Executed the P0s tests of the test plan
<!--- Include details of your test environment if relevant -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly