### PR TITLE
RMET-556 ::: iOS Fix Save Photo to Gallery

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -123,12 +123,12 @@
          </config-file>
          
          <preference name="LOCATION_WHENINUSE_USAGE_DESCRIPTION" default=" " />
-         <config-file target="NSLocationWhenInUseUsageDescription" file="*-Info.plist">
+         <config-file target="*-Info.plist" parent="NSLocationWhenInUseUsageDescription">
              <string>$LOCATION_WHENINUSE_USAGE_DESCRIPTION</string>
          </config-file>
 
          <preference name="PHOTOLIBRARY_ADD_USAGE_DESCRIPTION" default=" " />
-         <config-file target="NSPhotoLibraryAddUsageDescription" file="*-Info.plist">
+         <config-file target="*-Info.plist" parent="NSPhotoLibraryAddUsageDescription">
              <string>$PHOTOLIBRARY_ADD_USAGE_DESCRIPTION</string>
          </config-file>         
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
iOS fix for SaveToPhotoAlbum
There was a syntax error on the permission request for adding pictures to the photo gallery in the plugin.xml.

## Context
<!--- Place the link to the issue here preceded by either 'Closes' OR 'Fixes' -->
When taking a photo with the Save to gallery option on, app crashes.

Issue on JIRA:
https://outsystemsrd.atlassian.net/browse/RMET-556


<!--- Why is this change required? What problem does it solve? -->
Fix needed for releasing the plugin on Forge
 
## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Feature (change which adds functionality)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to new feature)
- [x] Fix (change which fixes an issue)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to fix)
- [ ] Performance (change which improves performance)
- [ ] BREAKING CHANGE (existing functionality will not work as expected due to performance improvement)
- [ ] Refactor (non-breaking change that is neither feature, fix nor performance)
- [ ] Style (non-breaking change that only affects formatting and/or white-space)

## Components affected
- [ ] Android platform
- [x] iOS platform
- [ ] JavaScript
- [ ] OutSystems

## Tests
<!--- Describe how you tested your changes in detail -->
Executed the P0s tests of the test plan
<!--- Include details of your test environment if relevant -->

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Tests have been created
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly