### PR TITLE
RMET-733 Camera Plugin - Add photo library permissions for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The changes documented here do not include those from the original repository.
+
+## [Unreleased]
+
+## 2021-05-28
+- Fix: Fixed iOS implementation to ask for photo library permissions when needed (https://outsystemsrd.atlassian.net/browse/RMET-733)

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -29,6 +29,7 @@
 #import <ImageIO/CGImageDestination.h>
 #import <MobileCoreServices/UTCoreTypes.h>
 #import <objc/message.h>
+#import <Photos/Photos.h>
 
 #ifndef __CORDOVA_4_0_0
     #import <Cordova/NSData+Base64.h>
@@ -209,9 +210,32 @@ static NSString* toBase64(NSData* data) {
             [self displayPopover:pictureOptions.popoverOptions];
             self.hasPendingOperation = NO;
         } else {
-            cameraPicker.modalPresentationStyle = UIModalPresentationCurrentContext;
-            [self.viewController presentViewController:cameraPicker animated:YES completion:^{
-                self.hasPendingOperation = NO;
+            [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+                switch (status) {
+                    case PHAuthorizationStatusAuthorized: {
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            cameraPicker.modalPresentationStyle = UIModalPresentationCurrentContext;
+                            [self.viewController presentViewController:cameraPicker animated:YES completion:^{
+                                self.hasPendingOperation = NO;
+                            }];
+                        });
+                        break;
+                    }
+                    case PHAuthorizationStatusRestricted: {
+                        dispatch_async(dispatch_get_main_queue(), ^{
+                            cameraPicker.modalPresentationStyle = UIModalPresentationCurrentContext;
+                            [self.viewController presentViewController:cameraPicker animated:YES completion:^{
+                                self.hasPendingOperation = NO;
+                            }];
+                        });
+                        break;
+                    }
+                    case PHAuthorizationStatusDenied:
+                        //do nothing
+                        break;
+                    default:
+                        break;
+                }
             }];
         }
     });

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -82,6 +82,7 @@ static NSString* toBase64(NSData* data) {
     pictureOptions.saveToPhotoAlbum = [[command argumentAtIndex:9 withDefault:@(NO)] boolValue];
     pictureOptions.popoverOptions = [command argumentAtIndex:10 withDefault:nil];
     pictureOptions.cameraDirection = [[command argumentAtIndex:11 withDefault:@(UIImagePickerControllerCameraDeviceRear)] unsignedIntegerValue];
+    pictureOptions.actionType = [command argumentAtIndex:12 withDefault:@("")];
 
     pictureOptions.popoverSupported = NO;
     pictureOptions.usesGeolocation = NO;
@@ -210,18 +211,26 @@ static NSString* toBase64(NSData* data) {
             [self displayPopover:pictureOptions.popoverOptions];
             self.hasPendingOperation = NO;
         } else {
-            __weak CDVCamera* weakSelf = self;
-//not available for MABS 6, should be used in the future
-//            if (@available(iOS 14,*)){
-//                [PHPhotoLibrary requestAuthorizationForAccessLevel:(PHAccessLevelReadWrite) handler:^(PHAuthorizationStatus status) {
-//                    [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
-//                }];
-//            }
-//            else{
-                [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
-                    [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
+            if ([pictureOptions.actionType isEqualToString:@"takePicture"]) {
+                cameraPicker.modalPresentationStyle = UIModalPresentationCurrentContext;
+                [self.viewController presentViewController:cameraPicker animated:YES completion:^{
+                    self.hasPendingOperation = NO;
                 }];
-//            }
+            }
+            else if ([pictureOptions.actionType isEqualToString:@"choosePicture"]){
+                __weak CDVCamera* weakSelf = self;
+    //not available for MABS 6, should be used in the future
+    //            if (@available(iOS 14,*)){
+    //                [PHPhotoLibrary requestAuthorizationForAccessLevel:(PHAccessLevelReadWrite) handler:^(PHAuthorizationStatus status) {
+    //                    [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
+    //                }];
+    //            }
+    //            else{
+                    [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+                        [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
+                    }];
+    //            }
+            }
         }
     });
 }

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -36,6 +36,7 @@
 #endif
 
 #define CDV_PHOTO_PREFIX @"cdv_photo_"
+#define SOURCE_TYPE_PHOTO_LIBRARY 0
 
 static NSSet* org_apache_cordova_validArrowDirections;
 
@@ -82,7 +83,6 @@ static NSString* toBase64(NSData* data) {
     pictureOptions.saveToPhotoAlbum = [[command argumentAtIndex:9 withDefault:@(NO)] boolValue];
     pictureOptions.popoverOptions = [command argumentAtIndex:10 withDefault:nil];
     pictureOptions.cameraDirection = [[command argumentAtIndex:11 withDefault:@(UIImagePickerControllerCameraDeviceRear)] unsignedIntegerValue];
-    pictureOptions.actionType = [command argumentAtIndex:12 withDefault:@("")];
 
     pictureOptions.popoverSupported = NO;
     pictureOptions.usesGeolocation = NO;
@@ -211,13 +211,16 @@ static NSString* toBase64(NSData* data) {
             [self displayPopover:pictureOptions.popoverOptions];
             self.hasPendingOperation = NO;
         } else {
-            if ([pictureOptions.actionType isEqualToString:@"takePicture"]) {
+            
+            if (pictureOptions.sourceType == UIImagePickerControllerSourceTypeCamera) {
                 cameraPicker.modalPresentationStyle = UIModalPresentationCurrentContext;
                 [self.viewController presentViewController:cameraPicker animated:YES completion:^{
                     self.hasPendingOperation = NO;
                 }];
             }
-            else if ([pictureOptions.actionType isEqualToString:@"choosePicture"]){
+            
+            //using constant instead of UIImagePickerControllerSoureTypePhotoLibrary because it is deprecated and will be removed soon
+            else if (pictureOptions.sourceType == SOURCE_TYPE_PHOTO_LIBRARY){
                 __weak CDVCamera* weakSelf = self;
     //not available for MABS 6, should be used in the future
     //            if (@available(iOS 14,*)){

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -211,9 +211,17 @@ static NSString* toBase64(NSData* data) {
             self.hasPendingOperation = NO;
         } else {
             __weak CDVCamera* weakSelf = self;
-            [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
-                [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
-            }];
+//not available for MABS 6, should be used in the future
+//            if (@available(iOS 14,*)){
+//                [PHPhotoLibrary requestAuthorizationForAccessLevel:(PHAccessLevelReadWrite) handler:^(PHAuthorizationStatus status) {
+//                    [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
+//                }];
+//            }
+//            else{
+                [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+                    [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
+                }];
+//            }
         }
     });
 }
@@ -235,6 +243,11 @@ static NSString* toBase64(NSData* data) {
             block();
             break;
         }
+//not available for MABS 6, should be used in the future
+//        case PHAuthorizationStatusLimited: {
+//            block();
+//            break;
+//        }
         case PHAuthorizationStatusDenied:
             //do nothing
             break;

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -211,16 +211,9 @@ static NSString* toBase64(NSData* data) {
             self.hasPendingOperation = NO;
         } else {
             __weak CDVCamera* weakSelf = self;
-            if (@available(iOS 14,*)){
-                [PHPhotoLibrary requestAuthorizationForAccessLevel:(PHAccessLevelReadWrite) handler:^(PHAuthorizationStatus status) {
-                    [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
-                }];
-            }
-            else{
-                [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
-                    [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
-                }];
-            }
+            [PHPhotoLibrary requestAuthorization:^(PHAuthorizationStatus status) {
+                [weakSelf handlePhotoLibraryPermissionsWithStatus:status andCameraPicker:cameraPicker];
+            }];
         }
     });
 }

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -235,10 +235,6 @@ static NSString* toBase64(NSData* data) {
             block();
             break;
         }
-        case PHAuthorizationStatusLimited: {
-            block();
-            break;
-        }
         case PHAuthorizationStatusDenied:
             //do nothing
             break;

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -148,10 +148,9 @@ cameraExport.getPicture = function (successCallback, errorCallback, options) {
     var saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     var popoverOptions = getValue(options.popoverOptions, null);
     var cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
-    var actionType = getValue(options.actionType, "");
 
     var args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
-        mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection, actionType];
+        mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
 
     exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
     // XXX: commented out

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -148,9 +148,10 @@ cameraExport.getPicture = function (successCallback, errorCallback, options) {
     var saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     var popoverOptions = getValue(options.popoverOptions, null);
     var cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+    var actionType = getValue(options.actionType, "");
 
     var args = [quality, destinationType, sourceType, targetWidth, targetHeight, encodingType,
-        mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection];
+        mediaType, allowEdit, correctOrientation, saveToPhotoAlbum, popoverOptions, cameraDirection, actionType];
 
     exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
     // XXX: commented out


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Added the code in iOS to check for photo library permissions and ask the user for them if necessary. This fix was requested in a support case (https://outsystemsrd.atlassian.net/browse/RMET-733).
Also added the GHANGELOG.md file to the repo (we were missing it).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
We were simply opening the photo library directly, which does not comply with Apple's privacy policy. Apps with this behaviour can be removed from the App Store.

References: https://outsystemsrd.atlassian.net/browse/RMET-733

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
All MABS builds working (6 and 7). Tested in iOS 14, 13, 12 and 11.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
