### PR TITLE
RMET-738 Camera Plugin - Fix conflict with file providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## [4.0.1-OS8]
+### Fixes
+- Fix: Fixed Android conflict with file providers (https://outsystemsrd.atlassian.net/browse/RMET-738)
 
 ## [4.0.1-OS7]
 ### Fixes

--- a/plugin.xml
+++ b/plugin.xml
@@ -60,7 +60,7 @@
         <config-file target="AndroidManifest.xml" parent="application">
           <provider
               android:name="org.apache.cordova.camera.FileProvider"
-              android:authorities="${applicationId}.provider"
+              android:authorities="${applicationId}.camera.provider"
               android:exported="false"
               android:grantUriPermissions="true" >
               <meta-data

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -304,7 +304,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         File photo = createCaptureFile(encodingType);
         this.imageFilePath = photo.getAbsolutePath();
         this.imageUri = FileProvider.getUriForFile(cordova.getActivity(),
-                applicationId + ".provider",
+                applicationId + ".camera.provider",
                 photo);
         intent.putExtra(MediaStore.EXTRA_OUTPUT, imageUri);
         //We can write to this URI, this will hopefully allow us to write files to get to the next step
@@ -851,7 +851,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 try {
                     if (this.allowEdit) {
                         Uri tmpFile = FileProvider.getUriForFile(cordova.getActivity(),
-                                applicationId + ".provider",
+                                applicationId + ".camera.provider",
                                 createCaptureFile(this.encodingType));
                         performCrop(tmpFile, destType, intent);
                     } else {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix conflict with file providers, when this plugin is used with more plugins, can try to use the wrong provider for camera.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-738

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
