### PR TITLE
RMET-738 Camera Plugin - Fix: apply correct orientation to PNG too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### Fixes
+- Fix: apply correct orientation to PNG too (https://outsystemsrd.atlassian.net/browse/RMET-739)
+
 ## [4.0.1-OS8]
 ### Fixes
 - Fix: Fixed Android conflict with file providers (https://outsystemsrd.atlassian.net/browse/RMET-738)

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -1009,19 +1009,16 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 galleryUri = Uri.fromFile(localFile);
                 writeUncompressedImage(fileStream, galleryUri);
                 try {
-                    String mimeType = FileHelper.getMimeType(imageUrl.toString(), cordova);
-                    if (JPEG_MIME_TYPE.equalsIgnoreCase(mimeType)) {
-                        //  ExifInterface doesn't like the file:// prefix
-                        String filePath = galleryUri.toString().replace("file://", "");
-                        // read exifData of source
-                        exifData = new ExifHelper();
-                        exifData.createInFile(filePath);
-                        exifData.readExifData();
-                        // Use ExifInterface to pull rotation information
-                        if (this.correctOrientation) {
-                            ExifInterface exif = new ExifInterface(filePath);
-                            rotate = exifToDegrees(exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED));
-                        }
+                    //  ExifInterface doesn't like the file:// prefix
+                    String filePath = galleryUri.toString().replace("file://", "");
+                    // read exifData of source
+                    exifData = new ExifHelper();
+                    exifData.createInFile(filePath);
+                    exifData.readExifData();
+                    // Use ExifInterface to pull rotation information
+                    if (this.correctOrientation) {
+                        ExifInterface exif = new ExifInterface(filePath);
+                        rotate = exifToDegrees(exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED));
                     }
                 } catch (Exception oe) {
                     LOG.w(LOG_TAG,"Unable to read Exif data: "+ oe.toString());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The correct orientation was applied just for JPEG format.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-739

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
