### PR TITLE
Fix image returned from camera pick not having correct orientation

### DIFF
--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -615,7 +615,6 @@ static NSString* toBase64(NSData* data) {
     if (cameraPicker.pictureOptions.allowsEditing && [mediaType isEqualToString:(NSString*)kUTTypeImage]) {
         self.imageInfo = info;
         UIImage* image = [info objectForKey:UIImagePickerControllerOriginalImage];
-        image = [image imageCorrectedForCaptureOrientation];
         CDVImageEditorInterface* editor = [[CDVImageEditorInterface alloc] init];
         UINavigationController* navVc = [[UINavigationController alloc] initWithRootViewController: [editor buildControllerWithImage:image delegate:self]];
         [[cameraPicker presentingViewController] dismissViewControllerAnimated:YES completion:nil];

--- a/src/ios/CDVImageEditorInterface.swift
+++ b/src/ios/CDVImageEditorInterface.swift
@@ -12,7 +12,8 @@ import UIKit
             saveImageFeature: PassthroughImageSaverImpl(),
             delegate: DelegationBinder(delegate: delegate)
         )
-        return ImageEditorViewController(image: image, controller: controller)
+
+        return ImageEditorViewController(image: image?.fixedOrientation(), controller: controller)
     }
 }
 

--- a/src/ios/ScaledImageView.swift
+++ b/src/ios/ScaledImageView.swift
@@ -21,7 +21,7 @@ class ScaledImageView: UIImageView {
             }
             sizeConstraint = nil
             sizeConstraint = heightAnchor.constraint(equalToConstant: scaledDimension())
-            sizeConstraint?.priority = .defaultHigh
+            sizeConstraint?.priority = .required
             sizeConstraint?.isActive = true
             break
         case .landscape:
@@ -31,7 +31,7 @@ class ScaledImageView: UIImageView {
             }
             sizeConstraint = nil
             sizeConstraint = widthAnchor.constraint(equalToConstant: scaledDimension())
-            sizeConstraint?.priority = .defaultHigh
+            sizeConstraint?.priority = .required
             sizeConstraint?.isActive = true
             break
         }


### PR DESCRIPTION
### Platforms affected

iOS

### Description
Fix image returned from camera pick not having correct orientation
Also use a better method to calculate true pixel image Rect
And adjust ImageView center when in landscape


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
