### PR TITLE
Add cordova EditImage action

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -140,6 +140,9 @@
              <feature name="Camera">
                  <param name="ios-package" value="CDVCamera" />
              </feature>
+             <feature name="EditImage">
+                 <param name="ios-package" value="CDVEditImage" />
+             </feature>
              <preference name="CameraUsesGeolocation" value="false" />
          </config-file>
 
@@ -169,6 +172,7 @@
          <source-file src="src/ios/TickLinesRectLayer.swift" />
          <source-file src="src/ios/UITraitCollection+Orientation.swift" />
          <source-file src="src/ios/CDVImageEditorInterface.swift" />
+         <source-file src="src/ios/CDVEditImage.swift" />
          <resource-file src="src/ios/CameraLocal.xcassets"/>
          <dependency url="https://github.com/agoncalvesos/cordova-plugin-add-swift-support" id="cordova-plugin-add-swift-support"/>
          <framework src="ImageIO.framework" weak="true" />

--- a/src/ios/CDVEditImage.swift
+++ b/src/ios/CDVEditImage.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+@objc(CDVEditImage)
+class CDVEditImage: CDVPlugin {
+    
+    static let shared = CDVEditImage()
+
+    private var plugin: CDVImageEditorInterface?
+    private var callbackId: String?
+
+    static func getInstance() -> CDVEditImage {
+        return shared
+    }
+    
+    override func pluginInitialize() {
+        self.plugin = CDVImageEditorInterface()
+    }
+    
+    override func onReset() {}
+    
+    @objc(edit:)
+    func edit(command: CDVInvokedUrlCommand) {
+        guard
+            let imageBase64 = (command.argument(at: 0) as? String),
+            let imageData = Data(base64Encoded: imageBase64),
+            let image = UIImage(data: imageData),
+            let vc = plugin?.buildController(image: image, delegate: self)
+        else {
+            let pluginResult = CDVPluginResult(status: .error, messageAs: "Invalid image data")
+            commandDelegate.send(pluginResult, callbackId: command.callbackId)
+            return
+        }
+        callbackId = command.callbackId
+        
+        self.viewController.present(vc, animated: true, completion: nil)
+    }
+}
+
+extension CDVEditImage: CDVImageEditorDelegate {
+    
+    func finishEditing(_ result: UIImage?, error: Error?) {
+        
+        struct SomethingWentWrong: Error {}
+        
+        guard
+            let image = result,
+            let imageData = image.pngData()
+        else {
+            let finalError = error ?? SomethingWentWrong()
+            let pluginResult = CDVPluginResult(status: .error, messageAs: finalError.localizedDescription)
+            commandDelegate.send(pluginResult, callbackId: callbackId)
+            return
+        }
+        
+        let pluginResult = CDVPluginResult(status: .ok, messageAs: imageData.base64EncodedString())
+        commandDelegate.send(pluginResult, callbackId: callbackId)
+    }
+    
+    func didCancelEdit() {
+        let pluginResult = CDVPluginResult(status: .noResult)
+        commandDelegate.send(pluginResult, callbackId: callbackId)
+    }
+}

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -182,4 +182,23 @@ cameraExport.cleanup = function (successCallback, errorCallback) {
     exec(successCallback, errorCallback, 'Camera', 'cleanup', []);
 };
 
+/**
+ * TODO: Description of functionality
+ */
+ cameraExport.editPicture = function (successCallback, errorCallback, options) {
+
+    argscheck.checkArgs('fFO', 'EditImage.edit', arguments);
+    options = options || {};
+    var getValue = argscheck.getValue;
+
+    var imageByteArray = getValue(options.image, null);
+
+    if(imageByteArray == null){
+        return
+    }
+
+    var args = [imageByteArray];
+    exec(successCallback, errorCallback, 'EditImage', 'edit', args);
+};
+
 module.exports = cameraExport;


### PR DESCRIPTION
### Platforms affected

iOS
Android
JS

### Description
Add cordova EditImage action

This will enable editing an image without the need of taking a picture
or loading a picture from device.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
