### PR TITLE
Refactor of CDVCamera legacy components to swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-07-13
+- Migrating package upload to newer Saucelabs API [RMET-761](https://outsystemsrd.atlassian.net/browse/RMET-761)
 ## [4.0.1-OS10 = 4.0.1-OS30]
 ### Feature
 - Feature: Add Crop, Rotate and Flip features on Android and iOS (https://outsystemsrd.atlassian.net/browse/RMET-626)(https://outsystemsrd.atlassian.net/browse/RMET-627)

--- a/CI/templates/pipeline_run.js
+++ b/CI/templates/pipeline_run.js
@@ -55,7 +55,6 @@ async function executePipeline(androidAppID, iosAppID, plugin, androidVersion, i
             "DATACENTER": center,
             "MABS": "latest",
             "PLUGIN_NAME": plugin,
-            "RETRY": "1",
             "TAGS": " ",
             "TEST_TYPE": "native",
             "THREADS": thrds,

--- a/CI/templates/pipeline_run.js
+++ b/CI/templates/pipeline_run.js
@@ -114,9 +114,9 @@ var iosDeviceVersion = process.env.npm_config_deviceIos;
 
 json.forEach(function(run) {
     if (run.platform == 'android') {
-        androidAppId = run.appID;
+        androidAppId = run.storageID;
     } else {
-        iosAppId = run.appID;
+        iosAppId = run.storageID;
     }
 });
 

--- a/src/ios/CDVCamera.swift
+++ b/src/ios/CDVCamera.swift
@@ -1,0 +1,114 @@
+import UIKit
+
+// Remove the S it was just so there was no conflicts withe the legacy class
+// Class name should be CDVCamera
+@objc(CDVSCamera)
+class CDVSCamera: CDVPlugin {
+    
+    struct SomethingWentWrong: Error {}
+    
+    static let shared = CDVSCamera()
+    private var plugin: CameraPickerInterface?
+    private var callbackId: String?
+    
+    static func getInstance() -> CDVSCamera {
+        return shared
+    }
+    
+    override func pluginInitialize() {
+        self.plugin = CameraPickerInterface()
+    }
+    
+    @objc(takePicture:)
+    func takePicture(command: CDVInvokedUrlCommand) {
+        self.callbackId = command.callbackId
+        let options = PictureOptions(command: command)
+        guard let plugin = plugin else {
+            returnError(SomethingWentWrong())
+            return
+        }
+        do {
+            try plugin.setOptions(options: options)
+            plugin.viewController = self.viewController
+            switch options.sourceType {
+            case .photoLibrary:
+                plugin.choosePicture { [weak self] in
+                    switch $0 {
+                    case let .success(media):
+                        guard let media = media else {
+                            self?.returnNoResult()
+                            return
+                        }
+                        self?.returnSuccess(media)
+                    case let .failure(error):
+                        self?.returnError(error)
+                    }
+                }
+            case .camera:
+                plugin.takePicture { [weak self] in
+                    switch $0 {
+                    case let .success(media):
+                        guard let media = media else {
+                            self?.returnNoResult()
+                            return
+                        }
+                        self?.returnSuccess(media)
+                    case let .failure(error):
+                        self?.returnError(error)
+                    }
+                }
+            }
+           
+        } catch {
+            returnError(error)
+        }
+    }
+    
+    private func returnError(_ error: Error) {
+        let result = CDVPluginResult(status: .error, messageAs: error.localizedDescription)
+        commandDelegate.send(result, callbackId: callbackId)
+    }
+    
+    private func returnNoResult() {
+        let result = CDVPluginResult(status: .noResult)
+        commandDelegate.send(result, callbackId: callbackId)
+    }
+    
+    private func returnSuccess(_ media: MediaWrapper) {
+        let result: CDVPluginResult
+        switch media {
+        case let .video(url):
+            result = CDVPluginResult(status: .ok, messageAs: url.absoluteString)
+        case let .pictureURL(url):
+            result = CDVPluginResult(status: .ok, messageAs: url.absoluteString)
+        case let .pictureData(data):
+            result = CDVPluginResult(status: .ok, messageAs: data.base64EncodedString())
+        case let .picture(image):
+            result = CDVPluginResult(status: .ok, messageAs: image.pngData()!.base64EncodedString())
+        }
+        commandDelegate.send(result, callbackId: callbackId)
+    }
+    
+}
+
+private extension PictureOptions {
+    
+    init(command: CDVInvokedUrlCommand) {
+        self.quality = (command.argument(at: 0) as? NSNumber)?.floatValue ?? 50
+        self.destination = (command.argument(at: 1) as? NSNumber).flatMap { DestinationType(rawValue: $0.intValue) } ?? .fileUri
+        self.sourceType = (command.argument(at: 2) as? NSNumber).flatMap { SourceType(rawValue: $0.intValue) } ?? .camera
+        
+        if let width = command.argument(at: 3) as? Double, let height = command.argument(at: 4) as? Double {
+            self.targetSize = CGSize(width: width, height: height)
+        } else {
+            self.targetSize = .zero
+        }
+        
+        self.encodingType = (command.argument(at: 5) as? NSNumber).flatMap { EncodingType(rawValue: $0.intValue) } ?? .jpeg
+        self.mediaType = (command.argument(at: 6) as? NSNumber).flatMap { MediaType(rawValue: $0.intValue) } ?? .picture
+        self.allowEdit = command.argument(at: 7) as? Bool ?? false
+        self.correctOrientation = command.argument(at: 8) as? Bool ?? false
+        self.saveToPhotoAlbum = command.argument(at: 9) as? Bool ?? false
+        self.cameraDirection = (command.argument(at: 11) as? NSNumber).flatMap { CameraDirection(rawValue: $0.intValue) } ?? .back
+    }
+}

--- a/src/ios/CameraFlowController.swift
+++ b/src/ios/CameraFlowController.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+class CameraFlowController {
+    
+    private let resultFeature = CameraResultFeature()
+    private let options: PictureOptions
+    private let completion: (Result<MediaWrapper?, Error>) -> ()
+    
+    init(options: PictureOptions, completion:@escaping (Result<MediaWrapper?, Error>) -> ()) {
+        self.options = options
+        self.completion = completion
+    }
+    
+    func takePicture(viewController: UIViewController) {
+        let controller = TakePictureController(options: self.options) { [weak self] in
+            guard let self = self else { return }
+            switch $0 {
+            case let .success(media):
+                switch media {
+                case let .picture(image) where self.options.allowEdit:
+                    self.editImage(image: image, viewController: viewController)
+                default:
+                    if media != nil {
+                        do {
+                            let result = try self.resultFeature.parseResult(options: self.options, media!)
+                            self.completion(.success(result))
+                        } catch {
+                            self.completion(.failure(error))
+                        }
+                    } else {
+                        self.completion($0)
+                    }
+                }
+            default:
+                self.completion($0)
+            }
+        }
+        let picker = PickerViewControllerWrapper(options: self.options, viewController: viewController)
+        picker.controller = controller
+        picker.showController()
+    }
+    
+    func choosePicture(viewController: UIViewController) {
+        let controller = ChoosePictureController(options: self.options) { [weak self] in
+            guard let self = self else { return }
+            switch $0 {
+            case let .success(media):
+                switch media {
+                case let .picture(image) where self.options.allowEdit:
+                    self.editImage(image: image, viewController: viewController)
+                default:
+                    if media != nil {
+                        do {
+                            let result = try self.resultFeature.parseResult(options: self.options, media!)
+                            self.completion(.success(result))
+                        } catch {
+                            self.completion(.failure(error))
+                        }
+                    } else {
+                        self.completion($0)
+                    }
+                }
+            default:
+                self.completion($0)
+            }
+        }
+        let picker = PickerViewControllerWrapper(options: self.options, viewController: viewController)
+        picker.controller = controller
+        picker.showController()
+    }
+    
+    private func editImage(image: UIImage, viewController: UIViewController) {
+        let controller = ImageEditorControllerImpl(
+            saveImageFeature: PassthroughImageSaverImpl(),
+            delegate: self
+        )
+
+        let vc = ImageEditorViewController(image: image.fixedOrientation(), controller: controller)
+        viewController.present(vc, animated: true, completion: nil)
+    }
+}
+
+private struct PassthroughImageSaverImpl: ImageSaveFeature {
+    func saveImage(_ image: UIImage, completion: @escaping (Result<Void, Error>) -> ()) {
+        completion(.success(()))
+    }
+}
+
+extension CameraFlowController: ImageEditorDelegate {
+    
+    func finishEditing(_ result: Result<UIImage, Error>) {
+        switch result {
+        case let .success(image):
+            do {
+                let resultingProduct = try resultFeature.parseResult(options: options, .picture(image))
+                completion(.success(resultingProduct))
+            } catch {
+                completion(.failure(error))
+            }
+        case let .failure(error):
+            completion(.failure(error))
+        }
+    }
+    
+    func didCancelEdit() {
+        completion(.success(nil))
+    }
+}

--- a/src/ios/CameraPickerInterface.swift
+++ b/src/ios/CameraPickerInterface.swift
@@ -1,0 +1,75 @@
+import Foundation
+import AVFoundation
+
+protocol CameraPickerInterfaceDelegate {
+    func didFinish(_ error: Error?)
+    func didCancel()
+}
+
+class CameraPickerInterface {
+    
+    enum CameraError: Error {
+        case missingInitialization
+        case noPermission(permission: AVAuthorizationStatus)
+        case theSourceTypeIsUnavailable(sourceType: UIImagePickerController.SourceType)
+    }
+    
+    var delegate: CameraPickerInterfaceDelegate?
+    var viewController: UIViewController?
+    private var options: PictureOptions?
+    private var permissions: PermissionsController?
+    private var flowController: CameraFlowController?
+    
+    func setOptions(options: PictureOptions) throws {
+        guard isSourceTypeAvailable(sourceType: options.sourceType.pickerType) else {
+            throw CameraError.theSourceTypeIsUnavailable(sourceType: options.sourceType.pickerType)
+        }
+        self.options = options
+    }
+    
+    func takePicture(completion: @escaping (Result<MediaWrapper?, Error>) -> ()) {
+        guard let options = options, let viewController = viewController else {
+            completion(.failure(CameraError.missingInitialization))
+            return
+        }
+        let permission = PermissionsController(viewController: viewController) { [weak self] in
+            guard let self = self else { return }
+            switch $0 {
+            case .authorized:
+                let flowController = CameraFlowController(options: options, completion: completion)
+                flowController.takePicture(viewController: viewController)
+                self.flowController = flowController
+                break
+            default:
+                completion(.failure(CameraError.noPermission(permission: $0)))
+            }
+        }
+        permission.validatePermissions(requestAccess: true)
+        self.permissions = permission
+    }
+    
+    func choosePicture(completion: @escaping (Result<MediaWrapper?, Error>) -> ()) {
+        guard let options = options, let viewController = viewController else {
+            completion(.failure(CameraError.missingInitialization))
+            return
+        }
+        let permission = PermissionsController(viewController: viewController) { [weak self] in
+            guard let self = self else { return }
+            switch $0 {
+            case .authorized:
+                let flowController = CameraFlowController(options: options, completion: completion)
+                flowController.choosePicture(viewController: viewController)
+                self.flowController = flowController
+                break
+            default:
+                completion(.failure(CameraError.noPermission(permission: $0)))
+            }
+        }
+        permission.validatePermissions(requestAccess: true)
+        self.permissions = permission
+    }
+}
+
+private func isSourceTypeAvailable(sourceType: UIImagePickerController.SourceType) -> Bool {
+    UIImagePickerController.isSourceTypeAvailable(sourceType)
+}

--- a/src/ios/CameraResultFeature.swift
+++ b/src/ios/CameraResultFeature.swift
@@ -1,0 +1,36 @@
+import Foundation
+import UIKit
+
+struct CameraResultFeature {
+    
+    func parseResult(options: PictureOptions, _ media: MediaWrapper) throws -> MediaWrapper {
+        switch media {
+        case let .picture(image):
+            switch options.destination {
+            case .nativeUri:
+                // TODO: Save image on library and return an asset URL
+                break
+            case .fileUri:
+                let pathExtension = options.encodingType == .jpeg ? "jpg" : "png"
+                let filePath = temporaryFilePath(pathExtension: pathExtension)
+                guard let data = image.parse(options: options) else { return media }
+                try data.write(to: URL(fileURLWithPath: filePath), options: .atomicWrite)
+                return .pictureURL(URL(fileURLWithPath: filePath))
+            case .dataUrl:
+                return image
+                    .parse(options: options)
+                    .map { MediaWrapper.pictureData($0) }
+                    ?? media
+            }
+        default:
+            return media
+        }
+        return media
+    }
+    
+    private func temporaryFilePath(pathExtension: String) -> String {
+        let docsPath = NSTemporaryDirectory()
+        let filename = UUID().uuidString
+        return "\(docsPath)/cdv_photo_\(filename).\(pathExtension)"
+    }
+}

--- a/src/ios/ChoosePictureController.swift
+++ b/src/ios/ChoosePictureController.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MobileCoreServices
+
+class ChoosePictureController {
+    
+    enum ChooseImageError: Error {
+        case somethingWentWrong
+    }
+    
+    private let options: PictureOptions
+    private let completion: (Result<MediaWrapper?, Error>) -> ()
+    
+    init(options: PictureOptions, completion: @escaping (Result<MediaWrapper?, Error>) -> ()) {
+        self.options = options
+        self.completion = completion
+    }
+}
+
+extension ChoosePictureController: PickerViewControllerWrapperDelegate {
+    
+    func didReturnInfo(_ info: [UIImagePickerController.InfoKey : Any]) {
+        if let mediaType = info[UIImagePickerController.InfoKey.mediaType] as? String, mediaType ==  String(kUTTypeImage) {
+            guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else {
+                completion(.failure(ChooseImageError.somethingWentWrong))
+                return
+            }
+            completion(.success(.picture(image)))
+        } else {
+            guard let url = info[UIImagePickerController.InfoKey.mediaURL] as? URL else {
+                completion(.failure(ChooseImageError.somethingWentWrong))
+                return
+            }
+            do {
+                completion(.success(.video(try createTmpFile(path: url))))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    func didCancel() {
+        completion(.success(nil))
+    }
+    
+    private func createTmpFile(path: URL) throws -> URL {
+        let pathExt = path.pathExtension
+        let destPath = URL(fileURLWithPath: temporaryFilePath(pathExtension: pathExt))
+        let fileManager = FileManager.default
+        try fileManager.copyItem(at: path, to: destPath)
+        return destPath
+        
+    }
+    
+    private func temporaryFilePath(pathExtension: String) -> String {
+        let docsPath = NSTemporaryDirectory()
+        let filename = UUID().uuidString
+        return "\(docsPath)/cdv_photo_\(filename).\(pathExtension)"
+    }
+}

--- a/src/ios/MediaWrapper.swift
+++ b/src/ios/MediaWrapper.swift
@@ -1,0 +1,8 @@
+import UIKit
+
+enum MediaWrapper {
+    case video(URL)
+    case picture(UIImage)
+    case pictureData(Data)
+    case pictureURL(URL)
+}

--- a/src/ios/PermissionsController.swift
+++ b/src/ios/PermissionsController.swift
@@ -1,0 +1,66 @@
+import UIKit
+import AVFoundation
+
+class PermissionsController {
+    
+    private let viewController: UIViewController
+    private let completion: (AVAuthorizationStatus) -> ()
+    
+    init(viewController: UIViewController, completion:@escaping (AVAuthorizationStatus) -> ()) {
+        self.viewController = viewController
+        self.completion = completion
+    }
+    
+    func validatePermissions(requestAccess: Bool) {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            completion(.authorized)
+        case .notDetermined:
+            if requestAccess {
+                AVCaptureDevice.requestAccess(for: .video) { [weak self] in
+                    if $0 {
+                        self?.completion(.authorized)
+                    } else {
+                        self?.completion(.denied)
+                    }
+                }
+            } else {
+                completion(.notDetermined)
+            }
+            break
+        case .restricted:
+            completion(.restricted)
+            break
+        case .denied:
+            completion(.denied)
+            break
+        default:
+            completion(.notDetermined)
+        }
+    }
+    
+    private func showAlertViewController(status: AVAuthorizationStatus) {
+        DispatchQueue.main.async { [weak self] in
+            let alertController = UIAlertController(title: Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "", message: NSLocalizedString("Access to the camera has been prohibited; please enable it in the Settings app to continue.", comment: ""), preferredStyle: .alert)
+            
+            let okAction = UIAlertAction(
+                title: NSLocalizedString("OK", comment: ""),
+                style: .default)
+            { [weak self] _ in
+                self?.completion(status)
+            }
+            
+            let settingsAction = UIAlertAction(
+                title: NSLocalizedString("Settings", comment: ""),
+                style: .default)
+            { _ in
+                UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!, options: [:], completionHandler: nil)
+                self?.completion(status)
+            }
+            
+            alertController.addAction(okAction)
+            alertController.addAction(settingsAction)
+            self?.viewController.present(alertController, animated: true, completion: nil)
+        }
+    }
+}

--- a/src/ios/PickerViewControllerWrapper.swift
+++ b/src/ios/PickerViewControllerWrapper.swift
@@ -1,0 +1,57 @@
+import UIKit
+import MobileCoreServices
+
+protocol PickerViewControllerWrapperDelegate {
+    func didReturnInfo(_ info: [UIImagePickerController.InfoKey : Any])
+    func didCancel()
+}
+
+class PickerViewControllerWrapper: NSObject {
+    
+    var controller: PickerViewControllerWrapperDelegate?
+    private let options: PictureOptions
+    private let viewController: UIViewController
+    private lazy var pickerController = UIImagePickerController(rootViewController: viewController)
+    
+    init(options: PictureOptions, viewController: UIViewController) {
+        self.viewController = viewController
+        self.options = options
+    }
+    
+    func showController() {
+        let options = self.options
+        DispatchQueue.main.async { [weak self] in
+            guard let pickerController = self?.pickerController else { return }
+            pickerController.sourceType = options.sourceType.pickerType
+            
+            switch options.sourceType {
+            case .camera:
+                pickerController.cameraDevice = options.cameraDirection.pickerType
+            default:
+                switch options.mediaType {
+                case .all:
+                    pickerController.mediaTypes = UIImagePickerController.availableMediaTypes(for: .photoLibrary) ?? []
+                case .video:
+                    pickerController.mediaTypes = [String(kUTTypeMovie)]
+                case .picture:
+                    pickerController.mediaTypes = [String(kUTTypeImage)]
+                }
+            }
+            
+            self?.viewController.present(pickerController, animated: true, completion: nil)
+        }
+    }
+}
+
+extension PickerViewControllerWrapper: UIImagePickerControllerDelegate {
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        controller?.didReturnInfo(info)
+        picker.dismiss(animated: true, completion: nil)
+    }
+    
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        controller?.didCancel()
+        picker.dismiss(animated: true, completion: nil)
+    }
+}

--- a/src/ios/PictureOptions.swift
+++ b/src/ios/PictureOptions.swift
@@ -1,0 +1,61 @@
+import Foundation
+import AVFoundation
+
+struct PictureOptions {
+    
+    enum DestinationType: Int {
+        case dataUrl
+        case fileUri
+        case nativeUri
+    }
+    
+    enum EncodingType: Int {
+        case jpeg
+        case png
+    }
+    
+    enum MediaType: Int {
+        case picture
+        case video
+        case all
+    }
+    
+    enum SourceType: Int {
+        case camera
+        case photoLibrary
+        
+        var pickerType: UIImagePickerController.SourceType {
+            switch self {
+            case .camera:
+                return .camera
+            default:
+                return .photoLibrary
+            }
+        }
+    }
+    
+    enum CameraDirection: Int {
+        case front
+        case back
+        
+        var pickerType: UIImagePickerController.CameraDevice {
+            switch self {
+            case .front:
+                return .front
+            default:
+                return .rear
+            }
+        }
+    }
+    
+    let quality: Float
+    let destination: DestinationType
+    let sourceType: SourceType
+    let targetSize: CGSize
+    let encodingType: EncodingType
+    let mediaType: MediaType
+    let allowEdit: Bool
+    let correctOrientation: Bool
+    let saveToPhotoAlbum: Bool
+    let cameraDirection: CameraDirection
+}

--- a/src/ios/TakePictureController.swift
+++ b/src/ios/TakePictureController.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MobileCoreServices
+
+class TakePictureController {
+    
+    enum TakeImageError: Error {
+        case somethingWentWrong
+    }
+    
+    private let options: PictureOptions
+    private let completion: (Result<MediaWrapper?, Error>) -> ()
+    
+    init(options: PictureOptions, completion: @escaping (Result<MediaWrapper?, Error>) -> ()) {
+        self.options = options
+        self.completion = completion
+    }
+}
+
+extension TakePictureController: PickerViewControllerWrapperDelegate {
+    
+    func didReturnInfo(_ info: [UIImagePickerController.InfoKey : Any]) {
+        if let mediaType = info[UIImagePickerController.InfoKey.mediaType] as? String, mediaType ==  String(kUTTypeImage) {
+            guard let image = info[UIImagePickerController.InfoKey.originalImage] as? UIImage else {
+                completion(.failure(TakeImageError.somethingWentWrong))
+                return
+            }
+            completion(.success(.picture(image)))
+        } else {
+            guard let url = info[UIImagePickerController.InfoKey.mediaURL] as? URL else {
+                completion(.failure(TakeImageError.somethingWentWrong))
+                return
+            }
+            do {
+                completion(.success(.video(try createTmpFile(path: url))))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+    
+    func didCancel() {
+        completion(.success(nil))
+    }
+    
+    private func createTmpFile(path: URL) throws -> URL {
+        let pathExt = path.pathExtension
+        let destPath = URL(fileURLWithPath: temporaryFilePath(pathExtension: pathExt))
+        let fileManager = FileManager.default
+        try fileManager.copyItem(at: path, to: destPath)
+        return destPath
+        
+    }
+    
+    private func temporaryFilePath(pathExtension: String) -> String {
+        let docsPath = NSTemporaryDirectory()
+        let filename = UUID().uuidString
+        return "\(docsPath)/cdv_photo_\(filename).\(pathExtension)"
+    }
+}

--- a/src/ios/UIImage+DataParse.swift
+++ b/src/ios/UIImage+DataParse.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIImage {
+    
+    func parse(options: PictureOptions) -> Data? {
+        switch options.encodingType {
+        case .jpeg:
+            return jpegData(compressionQuality: CGFloat(options.quality) / 100)
+        case .png:
+            return pngData()
+        }
+    }
+}


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation and Context

The camera code base is very hold, it has deprecated features since iOS 9 and code that is not used.

### Description

This refactor implements all the features provided before by the camera plugin into a swift code base.

This includes:

Removal of Popover code that is not supported anymore.
Removal of geolocation code that is never used.

Plugin Interface.
Camera Flow to control navigation flow.
PictureOptions parser.
MediaWrapper to improve passing data between components.
Take picture workflow (controller)
Choose picture workflow (controller)
Edit flow navigation.

### Missing work

Delete Legacy code, no need to use this code anymore.
Add UINavigationController with rootViewController the ImageEditorViewController and present that navigation controller or the Tool bars will not show.
Replace CVSCamera name by CDVCamera when work is completed.
PictureOptions were not tested, they might some errors on parsing.
correctOrientation feature is not implemented, and should be a line of code so easy :) .
saveToAlbum is not implemented but should be a line of code.
Error codes like we should do from now on.
Unit Tests.