### PR TITLE
RMET-812 Camera Plugin - Include queries actions for IMAGE_CAPTURE, GET_CONTENT and PICK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### Fixes
+- Fix: Fixed Camera not opening on Android 12 (targetSDK & compileSDK = 31) (https://outsystemsrd.atlassian.net/browse/RMET-812)
+
 ## [4.0.1-OS10 = 4.0.1-OS30]
 ### Feature
 - Feature: Add Crop, Rotate and Flip features on Android and iOS (https://outsystemsrd.atlassian.net/browse/RMET-626)(https://outsystemsrd.atlassian.net/browse/RMET-627)

--- a/plugin.xml
+++ b/plugin.xml
@@ -85,6 +85,20 @@
           <activity android:name="com.outsystems.imageeditor.view.ImageEditorActivity" android:theme="@android:style/Theme.Black.NoTitleBar"/>
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="/*">
+            <queries>
+                <intent>
+                    <action android:name="android.media.action.IMAGE_CAPTURE" />
+                </intent>
+                <intent>
+                    <action android:name="android.intent.action.GET_CONTENT" />
+                </intent>
+                <intent>
+                    <action android:name="android.intent.action.PICK" />
+                </intent>
+            </queries>
+        </config-file>
+
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/EditImage.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/camera" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

We were missing some `action` tags in the AndroidManifest.xml file. These are necessary for Android 12, at least to open the camera.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
The Camera on Android 12 was not being launched because IMAGE_CAPTURE and GET_CONTENT were missing. PICK is necessary because we use allowEdit.

References: https://outsystemsrd.atlassian.net/browse/RMET-812

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS 7.1 build working and plugin working fine. Same for MABS 8 (using the NativeShell Template). Tested on Android 12 and 11.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly


