### PR TITLE
RMET-954 ::: Fix/missing bridging header

### DIFF
--- a/hooks/install_prerequisites.js
+++ b/hooks/install_prerequisites.js
@@ -1,5 +1,5 @@
 
-console.log("Running hook to install image editor plugin pre-requisites");
+console.log("Running hook to install plugin node libs requirements");
 
 module.exports = function (context) {
   var child_process = require('child_process'),

--- a/plugin.xml
+++ b/plugin.xml
@@ -140,7 +140,7 @@
      <!-- ios -->
      <platform name="ios">
          <hook type="before_plugin_install" src="hooks/install_prerequisites.js"/>
-         <hook type="after_platform_add" src="hooks/add_swift_support.js" />
+         <!-- <hook type="after_platform_add" src="hooks/add_swift_support.js" /> -->
          <hook type="after_plugin_add" src="hooks/add_swift_support.js" />
          <config-file target="config.xml" parent="/*">
              <feature name="Camera">
@@ -180,7 +180,7 @@
          <source-file src="src/ios/CDVImageEditorInterface.swift" />
          <source-file src="src/ios/CDVEditImage.swift" />
          <resource-file src="src/ios/CameraLocal.xcassets"/>
-         <dependency url="https://github.com/agoncalvesos/cordova-plugin-add-swift-support" id="cordova-plugin-add-swift-support"/>
+         <!-- <dependency url="https://github.com/agoncalvesos/cordova-plugin-add-swift-support" id="cordova-plugin-add-swift-support"/> -->
          <framework src="ImageIO.framework" weak="true" />
          <framework src="CoreLocation.framework" />
          <framework src="CoreGraphics.framework" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -140,7 +140,6 @@
      <!-- ios -->
      <platform name="ios">
          <hook type="before_plugin_install" src="hooks/install_prerequisites.js"/>
-         <!-- <hook type="after_platform_add" src="hooks/add_swift_support.js" /> -->
          <hook type="after_plugin_add" src="hooks/add_swift_support.js" />
          <config-file target="config.xml" parent="/*">
              <feature name="Camera">
@@ -180,7 +179,6 @@
          <source-file src="src/ios/CDVImageEditorInterface.swift" />
          <source-file src="src/ios/CDVEditImage.swift" />
          <resource-file src="src/ios/CameraLocal.xcassets"/>
-         <!-- <dependency url="https://github.com/agoncalvesos/cordova-plugin-add-swift-support" id="cordova-plugin-add-swift-support"/> -->
          <framework src="ImageIO.framework" weak="true" />
          <framework src="CoreLocation.framework" />
          <framework src="CoreGraphics.framework" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Removed plugin dependency that was not needed and all the extra calls to the "local" hooks (it was also duplicated in the plugin.xml)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
The build was failing on MABS 7.1 because there were 3 calls to the same hook and a plugin dependency that was not needed.

References: https://outsystemsrd.atlassian.net/browse/RMET-954

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS 7.1 build working. Tested in iOS 14.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows the code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly
