### PR TITLE
RMET-1231 Removed iOS swift class Extensions

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -179,12 +179,8 @@
          <source-file src="src/ios/CAShapeLayer+LineHelper.swift" />
          <source-file src="src/ios/CropRectLayer.swift" />
          <source-file src="src/ios/CropView.swift" />
-         <source-file src="src/ios/CropView+DragEvents.swift" />
          <source-file src="src/ios/GridRectLayer.swift" />
          <source-file src="src/ios/ImageEditorController.swift" />
-         <source-file src="src/ios/ImageEditorController+Crop.swift" />
-         <source-file src="src/ios/ImageEditorController+Flip.swift" />
-         <source-file src="src/ios/ImageEditorController+Rotate.swift" />
          <source-file src="src/ios/ImageEditorViewController.swift" />
          <source-file src="src/ios/SaveImageURLFeature.swift" />
          <source-file src="src/ios/ScaledImageView.swift" />

--- a/src/ios/CDVEditImage.swift
+++ b/src/ios/CDVEditImage.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 @objc(CDVEditImage)
-class CDVEditImage: CDVPlugin {
+class CDVEditImage: CDVPlugin, CDVImageEditorDelegate {
     
     static let shared = CDVEditImage()
 
@@ -35,9 +35,6 @@ class CDVEditImage: CDVPlugin {
         let navVC = UINavigationController(rootViewController: vc)
         self.viewController.present(navVC, animated: true, completion: nil)
     }
-}
-
-extension CDVEditImage: CDVImageEditorDelegate {
     
     func finishEditing(_ result: UIImage?, error: Error?) {
         

--- a/src/ios/CropView.swift
+++ b/src/ios/CropView.swift
@@ -64,4 +64,234 @@ final class CropView: UIView {
         let frame = self.bounds.insetBy(dx: -20, dy: -20);
         return frame.contains(point) ? self : nil;
     }
+
+     @objc func drag(_ gesture: UIPanGestureRecognizer) {
+        switch (gesture.state, state) {
+        case (.began, .notDragging):
+            let point = gesture.location(in: self)
+            
+            state = isPanningACorner(point)
+            if state == .notDragging {
+                let panningSide = isPanningASide(point)
+                state = panningSide
+                
+                if panningSide == .notDragging {
+                    state = isPanningRect(point)
+                }
+            }
+            
+            if state != .notDragging { lastCropRect = cropRect }
+        case (.changed, .DraggingTop):
+            dragTop(gesture)
+        case (.changed, .DraggingBottom):
+            dragBottom(gesture)
+        case (.changed, .DraggingLeft):
+            dragLeft(gesture)
+        case (.changed, .DraggingRight):
+            dragRight(gesture)
+        case (.changed, .DraggingTopLeft):
+            dragCornerTopLeft(gesture)
+        case (.changed, .DraggingTopRight):
+            dragCornerTopRight(gesture)
+        case (.changed, .DraggingBottomLeft):
+            dragCornerBottomLeft(gesture)
+        case (.changed, .DraggingBottomRight):
+            dragCornerBottomRight(gesture)
+        case (.changed, .DraggingRect):
+            dragRect(gesture)
+        case (.ended, _):
+            state = .notDragging
+        default:
+            break
+        }
+    }
+    
+    @objc private func dragTop(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.inset(by: .init(top: translation.y, left: 0, bottom: 0, right: 0))
+        cropRect = isNewRectValid(newRect)
+    }
+    
+    @objc private func dragBottom(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.inset(by: .init(top: 0, left: 0, bottom: -translation.y, right: 0))
+        cropRect = isNewRectValid(newRect)
+    }
+    
+    @objc private func dragLeft(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.inset(by: .init(top: 0, left: translation.x, bottom: 0, right: 0))
+        cropRect = isNewRectValid(newRect)
+    }
+    
+    @objc private func dragRight(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.inset(by: .init(top: 0, left: 0, bottom: 0, right: -translation.x))
+        cropRect = isNewRectValid(newRect)
+    }
+    
+    @objc private func dragCornerTopRight(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.inset(by: .init(top: translation.y, left: 0, bottom: 0, right: -translation.x))
+        cropRect = isNewRectValid(newRect)
+    }
+    
+    @objc private func dragCornerTopLeft(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.inset(by: .init(top: translation.y, left: translation.x, bottom: 0, right: 0))
+        cropRect = isNewRectValid(newRect)
+    }
+    
+    @objc private func dragCornerBottomRight(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.inset(by: .init(top: 0, left: 0, bottom: -translation.y, right: -translation.x))
+        cropRect = isNewRectValid(newRect)
+    }
+    
+    @objc private func dragCornerBottomLeft(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.inset(by: .init(top: 0, left: translation.x, bottom: -translation.y, right: 0))
+        cropRect = isNewRectValid(newRect)
+    }
+    
+    @objc private func dragRect(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: self)
+        let newRect = lastCropRect.applying(.init(translationX: translation.x, y: translation.y))
+        cropRect = isDraggingRectValid(newRect)
+    }
+    
+    private func isNewRectValid(_ rect: CGRect) -> CGRect {
+        let minWidth: CGFloat = 63
+        let minHeight: CGFloat = 70
+        let minX: CGFloat = 0
+        let minY: CGFloat = 0
+        let maxX: CGFloat = self.bounds.width - minWidth
+        let maxY: CGFloat = self.bounds.height - minHeight
+        let x = max(minX, min(rect.origin.x, maxX))
+        let y = max(minY, min(rect.origin.y, maxY))
+        let maxWidth = self.bounds.width - x
+        let maxHeight = self.bounds.height - y
+        
+        let r = CGRect(
+            x: x,
+            y: y,
+            width: max(minWidth, min(rect.width, maxWidth)),
+            height: max(minHeight, min(rect.height, maxHeight))
+        )
+        return r
+    }
+    
+    private func isDraggingRectValid(_ rect: CGRect) -> CGRect {
+        let minX: CGFloat = 0
+        let minY: CGFloat = 0
+        let maxX: CGFloat = self.bounds.width - cropRect.width
+        let maxY: CGFloat = self.bounds.height - cropRect.height
+
+        return CGRect(
+            x: max(minX, min(rect.origin.x, maxX)),
+            y: max(minY, min(rect.origin.y, maxY)),
+            width: cropRect.width,
+            height: cropRect.height
+        )
+    }
+    
+    private func isPanningASide(_ point: CGPoint) -> State {
+        let cornerTopRect = CGRect(
+            x: cropRect.origin.x,
+            y: cropRect.origin.y - minimumEdgesOffset,
+            width: cropRect.width,
+            height: minimumEdgesOffset * 2
+        )
+        
+        let cornerBottomtRect = CGRect(
+            x: cropRect.origin.x,
+            y: cropRect.origin.y + cropRect.height - minimumEdgesOffset,
+            width: cropRect.width,
+            height: minimumEdgesOffset * 2
+        )
+        
+        let cornerLeftRect = CGRect(
+            x: cropRect.origin.x - minimumEdgesOffset,
+            y: cropRect.origin.y,
+            width: minimumEdgesOffset * 2,
+            height: cropRect.height
+        )
+        
+        let cornerRightRect = CGRect(
+            x: cropRect.origin.x + cropRect.width - minimumEdgesOffset,
+            y: cropRect.origin.y,
+            width: minimumEdgesOffset * 2,
+            height: cropRect.height
+        )
+        
+        if cornerTopRect.contains(point) {
+            return .DraggingTop
+        }
+        
+        if cornerBottomtRect.contains(point) {
+            return .DraggingBottom
+        }
+        
+        if cornerLeftRect.contains(point) {
+            return .DraggingLeft
+        }
+        
+        if cornerRightRect.contains(point) {
+            return .DraggingRight
+        }
+        
+        return .notDragging
+    }
+    
+    private func isPanningACorner(_ point: CGPoint) -> State {
+        let cornerTopLeftRect = CGRect(
+            x: cropRect.origin.x - minimumEdgesOffset,
+            y: cropRect.origin.y - minimumEdgesOffset,
+            width: minimumEdgesOffset * 2,
+            height: minimumEdgesOffset * 2
+        )
+        
+        let cornerTopRightRect = CGRect(
+            x: cropRect.origin.x + cropRect.width - minimumEdgesOffset,
+            y: cropRect.origin.y - minimumEdgesOffset,
+            width: minimumEdgesOffset * 2,
+            height: minimumEdgesOffset * 2
+        )
+        
+        let cornerBottomLeftRect = CGRect(
+            x: cropRect.origin.x - minimumEdgesOffset,
+            y: cropRect.origin.y + cropRect.height - minimumEdgesOffset,
+            width: minimumEdgesOffset * 2,
+            height: minimumEdgesOffset * 2
+        )
+        
+        let cornerBottomRightRect = CGRect(
+            x: cropRect.origin.x + cropRect.width - minimumEdgesOffset,
+            y: cropRect.origin.y + cropRect.height - minimumEdgesOffset,
+            width: minimumEdgesOffset * 2,
+            height: minimumEdgesOffset * 2
+        )
+        
+        if cornerTopLeftRect.contains(point) {
+            return .DraggingTopLeft
+        }
+        
+        if cornerTopRightRect.contains(point) {
+            return .DraggingTopRight
+        }
+        
+        if cornerBottomLeftRect.contains(point) {
+            return .DraggingBottomLeft
+        }
+        
+        if cornerBottomRightRect.contains(point) {
+            return .DraggingBottomRight
+        }
+        
+        return .notDragging
+    }
+    
+    private func isPanningRect(_ point: CGPoint) -> State {
+        cropRect.contains(point) ? .DraggingRect : .notDragging
+    }
 }

--- a/src/ios/ImageEditorController.swift
+++ b/src/ios/ImageEditorController.swift
@@ -36,4 +36,112 @@ struct ImageEditorControllerImpl: ImageEditorController {
     func flipImage(_ image: UIImage) -> UIImage {
         return flipHorizontaly(image)
     }
+    
+    func cropImage(_ image: UIImage, rect: CGRect) throws -> UIImage {
+        return image.croppedInRect(rect: rect)
+    }
+    
+    func flipHorizontaly(_ image: UIImage) -> UIImage {
+        return image.withHorizontallyFlippedOrientation()
+    }
+    
+    func rotateRightImage(_ image: UIImage) throws -> UIImage {
+        return try rotate(image, orientation: image.imageOrientation.right())
+    }
+    
+    func rotateLeftImage(_ image: UIImage) throws -> UIImage {
+        return try rotate(image, orientation: image.imageOrientation.left())
+    }
+    
+    func rotate(_ image: UIImage, orientation: UIImage.Orientation) throws -> UIImage {
+        return UIImage(cgImage: image.cgImage!, scale: image.imageRendererFormat.scale, orientation: orientation)
+    }
+}
+
+private extension UIImage {
+    func croppedInRect(rect: CGRect) -> UIImage {
+        func rad(_ degree: Double) -> CGFloat {
+            return CGFloat(degree / 180.0 * .pi)
+        }
+        var scale = CGPoint(x: self.scale, y: self.scale)
+        var rectTransform: CGAffineTransform
+        
+        switch imageOrientation {
+        case .left:
+            rectTransform = CGAffineTransform(rotationAngle: rad(90)).translatedBy(x: 0, y: -self.size.height)
+        case .right:
+            rectTransform = CGAffineTransform(rotationAngle: rad(-90)).translatedBy(x: -self.size.width, y: 0)
+        case .down:
+            rectTransform = CGAffineTransform(rotationAngle: rad(-180)).translatedBy(x: -self.size.width, y: -self.size.height)
+        case .leftMirrored:
+            rectTransform = CGAffineTransform(rotationAngle: rad(90)).translatedBy(x: 0, y: -self.size.height).translatedBy(x: 0, y: self.size.height)
+            scale = CGPoint(x: 1, y: -1)
+        case .rightMirrored:
+            rectTransform = CGAffineTransform(rotationAngle: rad(-90)).translatedBy(x: -self.size.width, y: 0).translatedBy(x: 0, y: self.size.height)
+            scale = CGPoint(x: 1, y: -1)
+        case .upMirrored:
+            rectTransform = CGAffineTransform.identity.translatedBy(x: self.size.width, y: 0)
+            scale = CGPoint(x: -1, y: 1)
+        case .downMirrored:
+            rectTransform = CGAffineTransform(rotationAngle: rad(-180)).translatedBy(x: -self.size.width, y: -self.size.height).translatedBy(x: self.size.width, y: 0)
+            scale = CGPoint(x: -1, y: 1)
+        default:
+            rectTransform = .identity
+        }
+        
+        rectTransform = rectTransform.scaledBy(x: scale.x, y: scale.y)
+        let transformedRect = rect.applying(rectTransform)
+        let imageRef = self.cgImage!.cropping(to: transformedRect)
+        let result = UIImage(cgImage: imageRef!, scale: self.scale, orientation: self.imageOrientation)
+        return result
+    }
+}
+
+private extension UIImage.Orientation {
+    
+    func left() -> UIImage.Orientation {
+        switch self {
+        case .up:
+            return .left
+        case .left:
+            return .down
+        case .down:
+            return .right
+        case .right:
+            return .up
+        case .upMirrored:
+            return .leftMirrored
+        case .leftMirrored:
+            return .downMirrored
+        case .downMirrored:
+            return .rightMirrored
+        case .rightMirrored:
+            return .upMirrored
+        default:
+            return self
+        }
+    }
+    
+    func right() -> UIImage.Orientation {
+        switch self {
+        case .up:
+            return .right
+        case .left:
+            return .up
+        case .down:
+            return .left
+        case .right:
+            return .down
+        case .upMirrored:
+            return .rightMirrored
+        case .leftMirrored:
+            return .upMirrored
+        case .downMirrored:
+            return .leftMirrored
+        case .rightMirrored:
+            return .downMirrored
+        default:
+            return self
+        }
+    }
 }

--- a/src/ios/ImageEditorViewController.swift
+++ b/src/ios/ImageEditorViewController.swift
@@ -222,11 +222,6 @@ final class ImageEditorViewController: UIViewController {
             
         }
     }
-}
-
-// MARK: Actions
-
-extension ImageEditorViewController {
     
     @objc func cancelEdit(_ sender: Any?) {
         self.dismiss(animated: true, completion: nil)
@@ -260,6 +255,8 @@ extension ImageEditorViewController {
         imageView.image = newImg
     }
 }
+
+// MARK: Actions
 
 private class ActionButton: UIButton {
     


### PR DESCRIPTION
### Platforms affected
- [X] iOS

### Motivation and Context
A client had an issue when creating an app with a Japanese name and including Camera Plugin.
The problem was on the Swift extensions.

### Description
https://outsystemsrd.atlassian.net/browse/RMET-1231

### Testing
Tested on MABS and iOS device

### Checklist
- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
