### PR TITLE
RMET-1272 Camera Plugin - Add dialog after denying photo permissions on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### Fixes
+- Fix: Fixed error messages when cancelling to take or choose a photo, and when permissions for these are denied.
+- Fix: Added dialog to be shown when permissions to the photo library are denied (https://outsystemsrd.atlassian.net/browse/RMET-1272).
+
 ## [4.2.0-OS34]
 ### Fixes
 - Fix: Removed Swift class extensions so plugin compiles with projects with non-ascii names.

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -166,7 +166,7 @@ static NSString* toBase64(NSData* data) {
                  {
                      // Denied; show an alert
                      dispatch_async(dispatch_get_main_queue(), ^{
-                         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the camera has been prohibited; please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
+                         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the camera has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
                          [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                              [weakSelf sendNoPermissionResult:command.callbackId];
                          }]];
@@ -256,7 +256,7 @@ static NSString* toBase64(NSData* data) {
     
     ReturnBlock blockDialog = ^void(){
         dispatch_async(dispatch_get_main_queue(), ^{
-            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the photos has been prohibited; please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
+            UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the photos has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
             [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                 [weakSelf sendNoPermissionResult:callbackId];
             }]];

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -709,7 +709,12 @@ static NSString* toBase64(NSData* data) {
         } else if (picker.sourceType != UIImagePickerControllerSourceTypeCamera && ! IsAtLeastiOSVersion(@"11.0") && [ALAssetsLibrary authorizationStatus] != ALAuthorizationStatusAuthorized) {
             result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to assets"];
         } else {
-            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No Image Selected"];
+            if(picker.sourceType == UIImagePickerControllerSourceTypeCamera){
+                result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No picture taken."];
+            }
+            else if(picker.sourceType == SOURCE_TYPE_PHOTO_LIBRARY){
+                result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"No image selected."];
+            }
         }
 
 

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -39,6 +39,8 @@
 #define CDV_PHOTO_PREFIX @"cdv_photo_"
 #define SOURCE_TYPE_PHOTO_LIBRARY 0
 
+#define SOURCE_TYPE_CAMERA 1
+
 static NSSet* org_apache_cordova_validArrowDirections;
 
 static NSString* toBase64(NSData* data) {
@@ -168,11 +170,11 @@ static NSString* toBase64(NSData* data) {
                      dispatch_async(dispatch_get_main_queue(), ^{
                          UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the camera has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
                          [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                             [weakSelf sendNoPermissionResult:command.callbackId andOperationType:1];
+                             [weakSelf sendNoPermissionResult:command.callbackId andOperationType:SOURCE_TYPE_CAMERA];
                          }]];
                          [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                              [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                             [weakSelf sendNoPermissionResult:command.callbackId andOperationType:1];
+                             [weakSelf sendNoPermissionResult:command.callbackId andOperationType:SOURCE_TYPE_CAMERA];
                          }]];
                          [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
                      });
@@ -258,11 +260,11 @@ static NSString* toBase64(NSData* data) {
         dispatch_async(dispatch_get_main_queue(), ^{
             UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the photos has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
             [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                [weakSelf sendNoPermissionResult:callbackId andOperationType:2];
+                [weakSelf sendNoPermissionResult:callbackId andOperationType:SOURCE_TYPE_PHOTO_LIBRARY];
             }]];
             [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                 [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                [weakSelf sendNoPermissionResult:callbackId andOperationType:2];
+                [weakSelf sendNoPermissionResult:callbackId andOperationType:SOURCE_TYPE_PHOTO_LIBRARY];
             }]];
             [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
         });
@@ -294,11 +296,11 @@ static NSString* toBase64(NSData* data) {
 {
     NSString* message = @"";
     
-    if(operationType == 1){
-        message = @"Access to the camera has been prohibited. Please enable it in the settings app.";
+    if(operationType == SOURCE_TYPE_CAMERA){
+        message = @"Access to the camera has been prohibited. Please enable it in the Settings app.";
     }
-    else if(operationType == 2){
-        message = @"Access to the photos has been prohibited. Please enable it in the settings app.";
+    else if(operationType == SOURCE_TYPE_PHOTO_LIBRARY){
+        message = @"Access to the photos has been prohibited. Please enable it in the Settings app.";
     }
     
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];   // error callback expects string ATM

--- a/src/ios/CDVCamera.m
+++ b/src/ios/CDVCamera.m
@@ -168,11 +168,11 @@ static NSString* toBase64(NSData* data) {
                      dispatch_async(dispatch_get_main_queue(), ^{
                          UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the camera has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
                          [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                             [weakSelf sendNoPermissionResult:command.callbackId];
+                             [weakSelf sendNoPermissionResult:command.callbackId andOperationType:1];
                          }]];
                          [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                              [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                             [weakSelf sendNoPermissionResult:command.callbackId];
+                             [weakSelf sendNoPermissionResult:command.callbackId andOperationType:1];
                          }]];
                          [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
                      });
@@ -258,11 +258,11 @@ static NSString* toBase64(NSData* data) {
         dispatch_async(dispatch_get_main_queue(), ^{
             UIAlertController *alertController = [UIAlertController alertControllerWithTitle:[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"] message:NSLocalizedString(@"Access to the photos has been prohibited. Please enable it in the Settings app to continue.", nil) preferredStyle:UIAlertControllerStyleAlert];
             [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"OK", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                [weakSelf sendNoPermissionResult:callbackId];
+                [weakSelf sendNoPermissionResult:callbackId andOperationType:2];
             }]];
             [alertController addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Settings", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
                 [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
-                [weakSelf sendNoPermissionResult:callbackId];
+                [weakSelf sendNoPermissionResult:callbackId andOperationType:2];
             }]];
             [weakSelf.viewController presentViewController:alertController animated:YES completion:nil];
         });
@@ -290,9 +290,18 @@ static NSString* toBase64(NSData* data) {
     }
 }
 
-- (void)sendNoPermissionResult:(NSString*)callbackId
+- (void)sendNoPermissionResult:(NSString*)callbackId andOperationType:(int) operationType
 {
-    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"has no access to camera"];   // error callback expects string ATM
+    NSString* message = @"";
+    
+    if(operationType == 1){
+        message = @"Access to the camera has been prohibited. Please enable it in the settings app.";
+    }
+    else if(operationType == 2){
+        message = @"Access to the photos has been prohibited. Please enable it in the settings app.";
+    }
+    
+    CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:message];   // error callback expects string ATM
 
     [self.commandDelegate sendPluginResult:result callbackId:callbackId];
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

We were missing a dialog showing a message similar to the one we show when permissions to the camera are denied, but this time for the photo library. This PR adds that dialog.

Also took the opportunity to fix some error messages. We were sending the same error messages for when permissions are denied to the camera and the photo library. We were also sending the same error message when we cancelled taking a photo or choosing one from the photo library. We added more suggestive error message to be able to distinguish the two cases.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-1272

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS builds working. Tested fixes with generated app in iPhone 11 running iOS 14.6.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly


