### PR TITLE
RMET-1437 Camera Plugin - Fix Kotlin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Fixes
+- Fix: Fixed plugin's Kotlin version to use the default version set by MABS (https://outsystemsrd.atlassian.net/browse/RMET-1437)
+
 ## [4.2.0-OS36]
 
 ### Fixes

--- a/plugin.xml
+++ b/plugin.xml
@@ -63,7 +63,6 @@
 
             <preference name="GradlePluginKotlinEnabled" value="true" />
             <preference name="GradlePluginKotlinCodeStyle" value="official" />
-            <!--<preference name="GradlePluginKotlinVersion" value="1.5.21" />-->
             <preference name="AndroidXEnabled" value="true"/>
 
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -63,7 +63,7 @@
 
             <preference name="GradlePluginKotlinEnabled" value="true" />
             <preference name="GradlePluginKotlinCodeStyle" value="official" />
-            <preference name="GradlePluginKotlinVersion" value="1.3.50" />
+            <preference name="GradlePluginKotlinVersion" value="1.5.21" />
             <preference name="AndroidXEnabled" value="true"/>
 
         </config-file>

--- a/plugin.xml
+++ b/plugin.xml
@@ -63,7 +63,7 @@
 
             <preference name="GradlePluginKotlinEnabled" value="true" />
             <preference name="GradlePluginKotlinCodeStyle" value="official" />
-            <preference name="GradlePluginKotlinVersion" value="1.5.21" />
+            <!--<preference name="GradlePluginKotlinVersion" value="1.5.21" />-->
             <preference name="AndroidXEnabled" value="true"/>
 
         </config-file>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We were setting a specific Kotlin version in the `plugin.xml` when we should use the version that already comes by default set by MABS (through the Cordova version that MABS is using).

For clatity:
- MABS 7 - Kotlin version 1.3.50
- MABS 8 - Kotlin version 1.5.21
Reference: https://success.outsystems.com/Support/Release_Notes/Mobile_Apps_Build_Service_Versions

We had version 1.3.50 in the plugin.xml and this was causing a build failure for one of our customers which opened a support case. This was due to an incompatibility between our Camera Plugin and a customer's custom plugin. 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-1437

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS 8 and 7 builds working. Tested Camera Plugin in our sample app with both versions and everything is working.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly


