### PR TITLE
RMET-1744 ::: New Error Codes and Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [4.2.0-OS39]
+### Fixes
+- Update error codes and messages for iOS. (https://outsystemsrd.atlassian.net/browse/RMET-1744)
+
 ## [4.2.0-OS38]
 ### Fixes
 - Removed hook that adds swift support and added the plugin as dependecy. (https://outsystemsrd.atlassian.net/browse/RMET-1680)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.2.0-OS38",
+  "version": "4.2.0-OS39",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="4.2.0-OS38">
+    version="4.2.0-OS39">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>
@@ -187,6 +187,7 @@
          <source-file src="src/ios/UITraitCollection+Orientation.swift" />
          <source-file src="src/ios/CDVImageEditorInterface.swift" />
          <source-file src="src/ios/CDVEditImage.swift" />
+         <source-file src="src/ios/CDVCameraError.swift" />
          <resource-file src="src/ios/CameraLocal.xcassets"/>
          <framework src="ImageIO.framework" weak="true" />
          <framework src="CoreLocation.framework" />

--- a/src/ios/CDVCameraError.swift
+++ b/src/ios/CDVCameraError.swift
@@ -1,0 +1,46 @@
+@objc enum CDVCameraErrorEnum: Int {
+    case cameraAccess = 3
+    case imageSelected = 5
+    case photoLibraryAccess = 6
+    case assetAccess = 7
+    case pictureTaken = 8
+    case cameraAvailable = 9
+    case invalidImageData = 10
+    case editingImage = 11
+    
+    case unknown = 0
+    
+    var code: String {
+        "OS-PLUG-CAMR-\(String(format: "%04d", self.rawValue))"
+    }
+    
+    var message: String {
+        switch self {
+        case .cameraAccess:
+            return "You need to provide access to your camera."
+        case .imageSelected:
+            return "No Image Selected."
+        case .photoLibraryAccess:
+            return "You need to provide access to your photo library."
+        case .assetAccess:
+            return "You need to provide access to your assets."
+        case .pictureTaken:
+            return "No Picture Taken."
+        case .cameraAvailable:
+            return "No camera is available."
+        case .invalidImageData:
+            return "The image contains invalid data."
+        case .editingImage:
+            return "There was an issue with editing the image."
+            
+        case .unknown:
+            return "Unknown error."
+        }
+    }
+}
+
+@objc class CDVCameraError: NSObject {
+    @objc static func dictionary(for error: CDVCameraErrorEnum) -> [String: String] {
+        return ["code": error.code, "message": error.message]
+    }
+}

--- a/src/ios/CDVEditImage.swift
+++ b/src/ios/CDVEditImage.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 @objc(CDVEditImage)
 class CDVEditImage: CDVPlugin, CDVImageEditorDelegate {
     
@@ -26,7 +24,7 @@ class CDVEditImage: CDVPlugin, CDVImageEditorDelegate {
             let image = UIImage(data: imageData),
             let vc = plugin?.buildController(image: image, delegate: self)
         else {
-            let pluginResult = CDVPluginResult(status: .error, messageAs: "Invalid image data")
+            let pluginResult = CDVPluginResult(status: .error, messageAs: CDVCameraError.dictionary(for: .invalidImageData))
             commandDelegate.send(pluginResult, callbackId: command.callbackId)
             return
         }
@@ -37,15 +35,12 @@ class CDVEditImage: CDVPlugin, CDVImageEditorDelegate {
     }
     
     func finishEditing(_ result: UIImage?, error: Error?) {
-        
-        struct SomethingWentWrong: Error {}
-        
         guard
             let image = result,
             let imageData = image.pngData()
         else {
-            let finalError = error ?? SomethingWentWrong()
-            let pluginResult = CDVPluginResult(status: .error, messageAs: finalError.localizedDescription)
+            print("There was an issue with editing: \(error?.localizedDescription ?? "No error description")")
+            let pluginResult = CDVPluginResult(status: .error, messageAs: CDVCameraError.dictionary(for: .editingImage))
             commandDelegate.send(pluginResult, callbackId: callbackId)
             return
         }


### PR DESCRIPTION
## Description
Introduce a new `CDVCameraError` class that deals with the presentation of the plugin's error codes and messages.

A Sample App build was generated in order to test the changes: https://engineering.outsystems.net/MABS/BuildDetail.aspx?BuildId=a5341d34c3dd95f70b8d397f29208da39d8240ce&StageId=3

## Context
https://outsystemsrd.atlassian.net/browse/RMET-1744

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
