### PR TITLE
RMET-1831 Camera Plugin - Android 13 permissions for media images and videos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+### Fixes
+- Added permission requests for Android 13. (https://outsystemsrd.atlassian.net/browse/RMET-1831)
+
 ## [4.2.0-OS39]
 ### Fixes
 - Update error codes and messages for iOS. (https://outsystemsrd.atlassian.net/browse/RMET-1744)

--- a/plugin.xml
+++ b/plugin.xml
@@ -69,6 +69,8 @@
 
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+            <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="application">

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -119,6 +119,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private static final int CROP_GALERY = 666;
 
     private static final String TIME_FORMAT = "yyyyMMdd_HHmmss";
+    
+    //we need literal values because we cannot simply do Manifest.permission.READ_MEDIA_IMAGES, because of the target sdk
+    private static final String READ_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES";
+    private static final String READ_MEDIA_VIDEO = "android.permission.READ_MEDIA_VIDEO";
 
     private int mQuality;                   // Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
     private int targetWidth;                // desired width of the image
@@ -220,8 +224,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                         PermissionHelper.requestPermission(this, SAVE_TO_ALBUM_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
                     }
 
-                    else if(Build.VERSION.SDK_INT >= 33 && (!PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES) || !PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO))){
-                        PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, new String[]{ Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_IMAGES});
+                    else if(Build.VERSION.SDK_INT >= 33 && (!PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES) || !PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO))){
+                        PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, new String[]{ READ_MEDIA_VIDEO, READ_MEDIA_IMAGES});
                     }
                     else {
                         this.getImage(this.srcType, destType, encodingType);
@@ -276,8 +280,8 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
                 PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) ||
                 (Build.VERSION.SDK_INT >= 33 &&
-                        PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO) &&
-                        PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES));
+                        PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO) &&
+                        PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES));
 
         boolean takePicturePermission = PermissionHelper.hasPermission(this, Manifest.permission.CAMERA);
 
@@ -313,7 +317,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE});
         } else if(!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT >= 33){
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC,
-                    new String[]{Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_IMAGES});
+                    new String[]{READ_MEDIA_VIDEO, READ_MEDIA_IMAGES});
         }
         else {
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, permissions);
@@ -1482,7 +1486,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             return new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};
         }
         else{
-            return new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO};
+            return new String[]{Manifest.permission.CAMERA, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO};
         }
     }
 

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -134,7 +134,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private boolean orientationCorrected;   // Has the picture's orientation been corrected
     private boolean allowEdit;              // Should we allow the user to crop the image.
 
-    protected final static String[] permissions = { Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE };
+    protected final static String[] permissions = createPermissionArray();
 
     public CallbackContext callbackContext;
     private int numPics;
@@ -216,9 +216,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 }
                 else if ((this.srcType == PHOTOLIBRARY) || (this.srcType == SAVEDPHOTOALBUM)) {
                     // FIXME: Stop always requesting the permission
-                    if(!PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+                    if(Build.VERSION.SDK_INT < 33 && !PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
                         PermissionHelper.requestPermission(this, SAVE_TO_ALBUM_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
-                    } else {
+                    }
+
+                    else if(Build.VERSION.SDK_INT >= 33 && (!PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES) || !PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO))){
+                        PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, new String[]{ Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_IMAGES});
+                    }
+                    else {
                         this.getImage(this.srcType, destType, encodingType);
                     }
                 }
@@ -266,8 +271,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param encodingType           Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
      */
     public void callTakePicture(int returnType, int encodingType) {
-        boolean saveAlbumPermission = PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
-                && PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+        boolean saveAlbumPermission = (Build.VERSION.SDK_INT < 33 &&
+                PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
+                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) ||
+                (Build.VERSION.SDK_INT >= 33 &&
+                        PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO) &&
+                        PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES));
+
         boolean takePicturePermission = PermissionHelper.hasPermission(this, Manifest.permission.CAMERA);
 
         // CB-10120: The CAMERA permission does not need to be requested unless it is declared
@@ -297,10 +308,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             takePicture(returnType, encodingType);
         } else if (saveAlbumPermission && !takePicturePermission) {
             PermissionHelper.requestPermission(this, TAKE_PIC_SEC, Manifest.permission.CAMERA);
-        } else if (!saveAlbumPermission && takePicturePermission) {
+        } else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT < 33) {
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC,
                     new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE});
-        } else {
+        } else if(!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT >= 33){
+            PermissionHelper.requestPermissions(this, TAKE_PIC_SEC,
+                    new String[]{Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_IMAGES});
+        }
+        else {
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, permissions);
         }
     }
@@ -1460,8 +1475,15 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     cropIntent,
                     requestCode + destType);
         }
+    }
 
-
+    private static String[] createPermissionArray(){
+        if(Build.VERSION.SDK_INT < 33){
+            return new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};
+        }
+        else{
+            return new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO};
+        }
     }
 
 }

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -19,6 +19,7 @@
 package org.apache.cordova.camera;
 
 import android.Manifest;
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.PendingIntent;
 import android.app.RecoverableSecurityException;
@@ -119,10 +120,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
     private static final int CROP_GALERY = 666;
 
     private static final String TIME_FORMAT = "yyyyMMdd_HHmmss";
-    
-    //we need literal values because we cannot simply do Manifest.permission.READ_MEDIA_IMAGES, because of the target sdk
-    private static final String READ_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES";
-    private static final String READ_MEDIA_VIDEO = "android.permission.READ_MEDIA_VIDEO";
 
     private int mQuality;                   // Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
     private int targetWidth;                // desired width of the image
@@ -220,16 +217,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 }
                 else if ((this.srcType == PHOTOLIBRARY) || (this.srcType == SAVEDPHOTOALBUM)) {
                     // FIXME: Stop always requesting the permission
-                    if(Build.VERSION.SDK_INT < 33 && !PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-                        PermissionHelper.requestPermission(this, SAVE_TO_ALBUM_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
-                    }
-
-                    else if(Build.VERSION.SDK_INT >= 33 && (!PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES) || !PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO))){
-                        PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, new String[]{ READ_MEDIA_VIDEO, READ_MEDIA_IMAGES});
-                    }
-                    else {
-                        this.getImage(this.srcType, destType, encodingType);
-                    }
+                    this.callPhotoLibrary(this.srcType, destType, encodingType);
                 }
             }
             catch (IllegalArgumentException e)
@@ -274,14 +262,15 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
      * @param returnType        Set the type of image to return.
      * @param encodingType           Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
      */
+    @TargetApi(33)
     public void callTakePicture(int returnType, int encodingType) {
 
         boolean saveAlbumPermission = (Build.VERSION.SDK_INT < 33 &&
                 PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
                 PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) ||
                 (Build.VERSION.SDK_INT >= 33 &&
-                        PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO) &&
-                        PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES));
+                        PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO) &&
+                        PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES));
 
         boolean takePicturePermission = PermissionHelper.hasPermission(this, Manifest.permission.CAMERA);
 
@@ -317,7 +306,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                     new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE});
         } else if(!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT >= 33){
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC,
-                    new String[]{READ_MEDIA_VIDEO, READ_MEDIA_IMAGES});
+                    new String[]{Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_IMAGES});
         }
         else {
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, permissions);
@@ -356,6 +345,20 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
 //        else
 //            LOG.d(LOG_TAG, "ERROR: You must use the CordovaInterface for this to work correctly. Please implement it in your activity");
+    }
+
+    @TargetApi(33)
+    public void callPhotoLibrary(int srcType, int destType, int encodingType){
+        if(Build.VERSION.SDK_INT < 33 && !PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+            PermissionHelper.requestPermission(this, SAVE_TO_ALBUM_SEC, Manifest.permission.READ_EXTERNAL_STORAGE);
+        }
+
+        else if(Build.VERSION.SDK_INT >= 33 && (!PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_IMAGES) || !PermissionHelper.hasPermission(this, Manifest.permission.READ_MEDIA_VIDEO))){
+            PermissionHelper.requestPermissions(this, SAVE_TO_ALBUM_SEC, new String[]{ Manifest.permission.READ_MEDIA_VIDEO, Manifest.permission.READ_MEDIA_IMAGES});
+        }
+        else {
+            this.getImage(srcType, destType, encodingType);
+        }
     }
 
     /**
@@ -1481,12 +1484,13 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
     }
 
+    @TargetApi(33)
     private static String[] createPermissionArray(){
         if(Build.VERSION.SDK_INT < 33){
             return new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE};
         }
         else{
-            return new String[]{Manifest.permission.CAMERA, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO};
+            return new String[]{Manifest.permission.CAMERA, Manifest.permission.READ_MEDIA_IMAGES, Manifest.permission.READ_MEDIA_VIDEO};
         }
     }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR changes the way we request permissions to access images and photos, according to the changes stated in the Android 13 release notes: https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions

The following build can be used to test the fix: https://engineering.outsystems.net/MABS/BuildDetail.aspx?BuildId=41d48adf0da1b0578b2be32cf6ed5b5b58a0407e&StageId=1

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-1831

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested on Android 13 with MABS 9 build. Also tested plugin in Android 12 with MABS 8.1 build.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly


