### PR TITLE
RMET-1745 Camera Plugin - Update error handling on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+### Fixes
+- Update the way we send errors from Android. (https://outsystemsrd.atlassian.net/browse/RMET-1745)
 
 ## [4.2.0-OS39]
 ### Fixes

--- a/plugin.xml
+++ b/plugin.xml
@@ -101,6 +101,7 @@
         </config-file>
 
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />
+        <source-file src="src/android/CameraError.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/EditImage.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/ExifHelper.java" target-dir="src/org/apache/cordova/camera" />

--- a/src/android/CameraError.java
+++ b/src/android/CameraError.java
@@ -1,0 +1,22 @@
+package org.apache.cordova.camera;
+
+public enum CameraError {
+
+    CAMERA_PERMISSION_DENIED_ERROR(3, "You need to provide access to your camera."),
+    GALLERY_PERMISSION_DENIED_ERROR(6, "You need to provide access to your photo library."),
+    NO_PICTURE_TAKEN_ERROR(8, "No picture taken."),
+    NO_IMAGE_SELECTED_ERROR(5, "No image selected."),
+    EDIT_IMAGE_ERROR (11, "There was an issue with editing the image."),
+    GET_IMAGE_ERROR(13, "Could not take photo."),
+    TAKE_PHOTO_ERROR(12, "Could not get image from photo library."),
+    PROCESS_IMAGE_ERROR(14, "There was an issue processing the image.");
+
+    final int code;
+    final String message;
+
+    CameraError(int code, String message){
+        this.code = code;
+        this.message = message;
+    }
+
+}

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -536,7 +536,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             // Double-check the bitmap.
             if (bitmap == null) {
                 LOG.d(LOG_TAG, "I either have a null image path or bitmap");
-                sendError(TAKE_PHOTO_ERROR.first, TAKE_PHOTO_ERROR.second);
+                sendError(TAKE_PHOTO_ERROR);
                 return;
             }
 
@@ -578,7 +578,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 // Double-check the bitmap.
                 if (bitmap == null) {
                     LOG.d(LOG_TAG, "I either have a null image path or bitmap");
-                    sendError(TAKE_PHOTO_ERROR.first, TAKE_PHOTO_ERROR.second);
+                    sendError(TAKE_PHOTO_ERROR);
                     return;
                 }
 
@@ -722,7 +722,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             if (croppedUri != null) {
                 uri = croppedUri;
             } else {
-                sendError(GET_IMAGE_ERROR.first, GET_IMAGE_ERROR.second);
+                sendError(GET_IMAGE_ERROR);
                 return;
             }
         }
@@ -758,7 +758,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 }
                 if (bitmap == null) {
                     LOG.d(LOG_TAG, "I either have a null image path or bitmap");
-                    sendError(GET_IMAGE_ERROR.first, GET_IMAGE_ERROR.second);
+                    sendError(GET_IMAGE_ERROR);
                     return;
                 }
 
@@ -782,7 +782,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
                         } catch (Exception e) {
                             e.printStackTrace();
-                            sendError(GET_IMAGE_ERROR.first, GET_IMAGE_ERROR.second);
+                            sendError(GET_IMAGE_ERROR);
                         }
                     } else {
                         this.callbackContext.success(fileLocation);
@@ -825,10 +825,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             }
             else if (resultCode == Activity.RESULT_CANCELED) {
-                sendError(NO_IMAGE_SELECTED_ERROR.first, NO_IMAGE_SELECTED_ERROR.second);
+                sendError(NO_IMAGE_SELECTED_ERROR);
             }
             else {
-                sendError(EDIT_IMAGE_ERROR.first, EDIT_IMAGE_ERROR.second);
+                sendError(EDIT_IMAGE_ERROR);
             }
         }
         else if (requestCode >= CROP_CAMERA) {
@@ -846,12 +846,12 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             }// If cancelled
             else if (resultCode == Activity.RESULT_CANCELED) {
-                sendError(NO_PICTURE_TAKEN_ERROR.first, NO_PICTURE_TAKEN_ERROR.second);
+                sendError(NO_PICTURE_TAKEN_ERROR);
             }
 
             // If something else
             else {
-                sendError(EDIT_IMAGE_ERROR.first, EDIT_IMAGE_ERROR.second);
+                sendError(EDIT_IMAGE_ERROR);
             }
         }
         // If CAMERA
@@ -873,18 +873,18 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
                 } catch (IOException e) {
                     e.printStackTrace();
-                    sendError(TAKE_PHOTO_ERROR.first, TAKE_PHOTO_ERROR.second);
+                    sendError(TAKE_PHOTO_ERROR);
                 }
             }
 
             // If cancelled
             else if (resultCode == Activity.RESULT_CANCELED) {
-                sendError(NO_PICTURE_TAKEN_ERROR.first, NO_PICTURE_TAKEN_ERROR.second);
+                sendError(NO_PICTURE_TAKEN_ERROR);
             }
 
             // If something else
             else {
-                sendError(TAKE_PHOTO_ERROR.first, TAKE_PHOTO_ERROR.second);
+                sendError(TAKE_PHOTO_ERROR);
             }
         }
         // If retrieving photo from library
@@ -908,9 +908,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             }
             else if (resultCode == Activity.RESULT_CANCELED) {
-                sendError(NO_IMAGE_SELECTED_ERROR.first, NO_IMAGE_SELECTED_ERROR.second);
+                sendError(NO_IMAGE_SELECTED_ERROR);
             } else {
-                sendError(GET_IMAGE_ERROR.first, GET_IMAGE_ERROR.second);
+                sendError(GET_IMAGE_ERROR);
             }
         }
         else if(requestCode == RECOVERABLE_DELETE_REQUEST){
@@ -1356,7 +1356,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 code = null;
             }
         } catch (Exception e) {
-            sendError(PROCESS_IMAGE_ERROR.first, PROCESS_IMAGE_ERROR.second);
+            sendError(PROCESS_IMAGE_ERROR);
         }
         jpeg_data = null;
     }
@@ -1397,14 +1397,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
         for (int i = 0; i < grantResults.length; i++) {
             if (grantResults[i] == PackageManager.PERMISSION_DENIED && permissions[i].equals(Manifest.permission.CAMERA)) {
-                sendError(CAMERA_PERMISSION_DENIED_ERROR.first, CAMERA_PERMISSION_DENIED_ERROR.second);
+                sendError(CAMERA_PERMISSION_DENIED_ERROR);
                 return;
             }
             else if(grantResults[i] == PackageManager.PERMISSION_DENIED && ((Build.VERSION.SDK_INT < 33
                     && (permissions[i].equals(Manifest.permission.READ_EXTERNAL_STORAGE) || permissions[i].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)))
                     || (Build.VERSION.SDK_INT >= 33
                     && (permissions[i].equals(READ_MEDIA_IMAGES) || permissions[i].equals(READ_MEDIA_VIDEO))))){
-                sendError(GALLERY_PERMISSION_DENIED_ERROR.first, GALLERY_PERMISSION_DENIED_ERROR.second);
+                sendError(GALLERY_PERMISSION_DENIED_ERROR);
                 return;
             }
         }
@@ -1510,11 +1510,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
     }
 
-    private void sendError(int code, String message){
+    private void sendError(Pair<Integer, String> error){
         JSONObject jsonResult = new JSONObject();
         try{
-            jsonResult.put("code", formatErrorCode(code));
-            jsonResult.put("message", message);
+            jsonResult.put("code", formatErrorCode(error.first));
+            jsonResult.put("message", error.second);
             this.callbackContext.error(jsonResult);
         }catch (JSONException e){
             LOG.d(LOG_TAG, "Error: JSONException occurred while preparing to send an error.");

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -127,14 +127,6 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
     //for errors
     private static final String ERROR_FORMAT_PREFIX = "OS-PLUG-CAMR-";
-    private static final Pair<Integer, String> CAMERA_PERMISSION_DENIED_ERROR = new Pair(3, "You need to provide access to your camera.");
-    private static final Pair<Integer, String> GALLERY_PERMISSION_DENIED_ERROR = new Pair(6, "You need to provide access to your photo library.");
-    private static final Pair<Integer, String> NO_PICTURE_TAKEN_ERROR = new Pair(8, "No picture taken.");
-    private static final Pair<Integer, String> NO_IMAGE_SELECTED_ERROR = new Pair(5, "No image selected.");
-    private static final Pair<Integer, String> EDIT_IMAGE_ERROR = new Pair(11, "There was an issue with editing the image.");
-    private static final Pair<Integer, String> GET_IMAGE_ERROR = new Pair(13, "Could not take photo.");
-    private static final Pair<Integer, String> TAKE_PHOTO_ERROR = new Pair(12, "Could not get image from photo library.");
-    private static final Pair<Integer, String> PROCESS_IMAGE_ERROR = new Pair(14, "There was an issue processing the image.");
 
     private int mQuality;                   // Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
     private int targetWidth;                // desired width of the image

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -536,7 +536,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             // Double-check the bitmap.
             if (bitmap == null) {
                 LOG.d(LOG_TAG, "I either have a null image path or bitmap");
-                sendError(TAKE_PHOTO_ERROR);
+                sendError(CameraError.TAKE_PHOTO_ERROR);
                 return;
             }
 
@@ -578,7 +578,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 // Double-check the bitmap.
                 if (bitmap == null) {
                     LOG.d(LOG_TAG, "I either have a null image path or bitmap");
-                    sendError(TAKE_PHOTO_ERROR);
+                    sendError(CameraError.TAKE_PHOTO_ERROR);
                     return;
                 }
 
@@ -722,7 +722,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
             if (croppedUri != null) {
                 uri = croppedUri;
             } else {
-                sendError(GET_IMAGE_ERROR);
+                sendError(CameraError.GET_IMAGE_ERROR);
                 return;
             }
         }
@@ -758,7 +758,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 }
                 if (bitmap == null) {
                     LOG.d(LOG_TAG, "I either have a null image path or bitmap");
-                    sendError(GET_IMAGE_ERROR);
+                    sendError(CameraError.GET_IMAGE_ERROR);
                     return;
                 }
 
@@ -782,7 +782,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
                         } catch (Exception e) {
                             e.printStackTrace();
-                            sendError(GET_IMAGE_ERROR);
+                            sendError(CameraError.GET_IMAGE_ERROR);
                         }
                     } else {
                         this.callbackContext.success(fileLocation);
@@ -825,10 +825,10 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             }
             else if (resultCode == Activity.RESULT_CANCELED) {
-                sendError(NO_IMAGE_SELECTED_ERROR);
+                sendError(CameraError.NO_IMAGE_SELECTED_ERROR);
             }
             else {
-                sendError(EDIT_IMAGE_ERROR);
+                sendError(CameraError.EDIT_IMAGE_ERROR);
             }
         }
         else if (requestCode >= CROP_CAMERA) {
@@ -846,12 +846,12 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             }// If cancelled
             else if (resultCode == Activity.RESULT_CANCELED) {
-                sendError(NO_PICTURE_TAKEN_ERROR);
+                sendError(CameraError.NO_PICTURE_TAKEN_ERROR);
             }
 
             // If something else
             else {
-                sendError(EDIT_IMAGE_ERROR);
+                sendError(CameraError.EDIT_IMAGE_ERROR);
             }
         }
         // If CAMERA
@@ -873,18 +873,18 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
                 } catch (IOException e) {
                     e.printStackTrace();
-                    sendError(TAKE_PHOTO_ERROR);
+                    sendError(CameraError.TAKE_PHOTO_ERROR);
                 }
             }
 
             // If cancelled
             else if (resultCode == Activity.RESULT_CANCELED) {
-                sendError(NO_PICTURE_TAKEN_ERROR);
+                sendError(CameraError.NO_PICTURE_TAKEN_ERROR);
             }
 
             // If something else
             else {
-                sendError(TAKE_PHOTO_ERROR);
+                sendError(CameraError.TAKE_PHOTO_ERROR);
             }
         }
         // If retrieving photo from library
@@ -908,9 +908,9 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
             }
             else if (resultCode == Activity.RESULT_CANCELED) {
-                sendError(NO_IMAGE_SELECTED_ERROR);
+                sendError(CameraError.NO_IMAGE_SELECTED_ERROR);
             } else {
-                sendError(GET_IMAGE_ERROR);
+                sendError(CameraError.GET_IMAGE_ERROR);
             }
         }
         else if(requestCode == RECOVERABLE_DELETE_REQUEST){
@@ -1356,7 +1356,7 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
                 code = null;
             }
         } catch (Exception e) {
-            sendError(PROCESS_IMAGE_ERROR);
+            sendError(CameraError.PROCESS_IMAGE_ERROR);
         }
         jpeg_data = null;
     }
@@ -1397,14 +1397,14 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
 
         for (int i = 0; i < grantResults.length; i++) {
             if (grantResults[i] == PackageManager.PERMISSION_DENIED && permissions[i].equals(Manifest.permission.CAMERA)) {
-                sendError(CAMERA_PERMISSION_DENIED_ERROR);
+                sendError(CameraError.CAMERA_PERMISSION_DENIED_ERROR);
                 return;
             }
             else if(grantResults[i] == PackageManager.PERMISSION_DENIED && ((Build.VERSION.SDK_INT < 33
                     && (permissions[i].equals(Manifest.permission.READ_EXTERNAL_STORAGE) || permissions[i].equals(Manifest.permission.WRITE_EXTERNAL_STORAGE)))
                     || (Build.VERSION.SDK_INT >= 33
                     && (permissions[i].equals(READ_MEDIA_IMAGES) || permissions[i].equals(READ_MEDIA_VIDEO))))){
-                sendError(GALLERY_PERMISSION_DENIED_ERROR);
+                sendError(CameraError.GALLERY_PERMISSION_DENIED_ERROR);
                 return;
             }
         }
@@ -1510,11 +1510,11 @@ public class CameraLauncher extends CordovaPlugin implements MediaScannerConnect
         }
     }
 
-    private void sendError(Pair<Integer, String> error){
+    private void sendError(CameraError error){
         JSONObject jsonResult = new JSONObject();
         try{
-            jsonResult.put("code", formatErrorCode(error.first));
-            jsonResult.put("message", error.second);
+            jsonResult.put("code", formatErrorCode(error.code));
+            jsonResult.put("message", error.message);
             this.callbackContext.error(jsonResult);
         }catch (JSONException e){
             LOG.d(LOG_TAG, "Error: JSONException occurred while preparing to send an error.");

--- a/src/android/CameraLauncher.java
+++ b/src/android/CameraLauncher.java
@@ -45,7 +45,6 @@ import android.os.FileUtils;
 import android.provider.MediaStore;
 import androidx.core.content.FileProvider;
 import android.util.Base64;
-import android.util.Pair;
 import android.widget.Toast;
 
 import com.outsystems.imageeditor.view.ImageEditorActivity;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This PR changes the way we send the errors from the Android native code. Before this, we were only sending an error message, without a corresponding code. Error messages were also too technical. We updated this so that the error object sent has an error code and an error message, following our architecture for others plugins.

The following build can be used to test the fix: https://engineering.outsystems.net/MABS/BuildDetail.aspx?BuildId=8b9dd7af3eae2b2d2c80ca6055a1c0e0b0ac69e3&StageId=1

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-1745

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested on Android 13 with MABS 9 build. Also tested plugin in Android 12 with MABS 8.1 build.

## Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/27646996/191579951-5209678c-a9a8-429d-b36a-1d8cf1d90bdc.png)


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [x] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly


