### PR TITLE
RMET-1241 ::: iOS ::: App crash on Picture Editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+### Fixes
+- [iOS] App crash when editing a picture after selecting it (https://outsystemsrd.atlassian.net/browse/RMET-1241).
 
 ## [4.2.0-OS40]
 ### Fixes

--- a/src/ios/SaveImageURLFeature.swift
+++ b/src/ios/SaveImageURLFeature.swift
@@ -47,9 +47,15 @@ extension UIImage {
         default: break
         }
 
-        let ctx = CGContext(data: nil, width: Int(size.width), height: Int(size.height),
-                                       bitsPerComponent: cgImage!.bitsPerComponent, bytesPerRow: 0,
-                                       space: cgImage!.colorSpace!, bitmapInfo: cgImage!.bitmapInfo.rawValue)!
+        let ctx = CGContext(
+            data: nil,
+            width: Int(size.width),
+            height: Int(size.height),
+            bitsPerComponent: cgImage!.bitsPerComponent,
+            bytesPerRow: 0,
+            space: cgImage!.colorSpace!,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
         ctx.concatenate(transform)
 
         switch imageOrientation {


### PR DESCRIPTION
## Description
Fix the issue caused by creating a CGContext with the `cgImage`'s bitmap info. This was replaced with Apple's recommend `CGImageAlphaInfo.premultipliedLast`.

A Sample App build was generated in order to test the changes: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=9ead79f5d18efdaf6e71e83ad0d24ea200c1d245

## Context
https://outsystemsrd.atlassian.net/browse/RMET-1241

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly