### PR TITLE
Updating StampsInformation to service account on mobile-neo1

### DIFF
--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -35,14 +35,14 @@ stages:
           - checkout: MobilePluginsODCPipeline
           - template: build/ci/update-wrapper.yaml@MobilePluginsODCPipeline
             parameters:
-              secretFileName: "eng-osrd-mobile-forge-StampsInformation.json"
+              secretFileName: "eng-osrd-mobile-neo1-StampsInformation.json"
               PLUGIN_APP_KEY: "7acb2c1d-51bf-4ef4-8cb8-a05573501b6a"
               PLUGIN_UPDATE_URL: "https://github.com/OutSystems/cordova-plugin-camera#$(Build.SourceBranchName)"
               PLUGIN_UPDATE_VERSION: "$(Build.SourceBranchName)"
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsODCPipeline
           - template: build/ci/refresh-sampleapp.yaml@MobilePluginsODCPipeline
             parameters:
-              secretFileName: "eng-osrd-mobile-forge-StampsInformation.json"
+              secretFileName: "eng-osrd-mobile-neo1-StampsInformation.json"
               SAMPLEAPP_APP_KEY: "3c0451ef-0d99-4e09-adb5-718e009deb9d"
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsODCPipeline
           - script: |


### PR DESCRIPTION
### Description
Updates the pipeline configuration to use the Secure File with authentication details for eng-osrd-mobile-neo1

Account was also added to the team password manager shared folder.


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
