### PR TITLE
RMET-2403 Camera Lib Android - Fix null intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The changes documented here do not include those from the original repository.
 - [iOS] Implement `Edit Picture` client action (https://outsystemsrd.atlassian.net/browse/RMET-2222).
 
 ### Fixes
+- [Android] Fixed issue when intent is null (https://outsystemsrd.atlassian.net/browse/RMET-2403)
 - [iOS] App crash when editing a picture after selecting it (https://outsystemsrd.atlassian.net/browse/RMET-1241).
 
 ## [4.2.0-OS40]

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation("com.github.outsystems:oscore-android:1.1.0@aar")
   implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
   //TODO Update library version for to match the last camera lib android before release
-  implementation("com.github.outsystems:oscamera-android:0.0.20.3@aar")
+  implementation("com.github.outsystems:oscamera-android:0.0.20.4@aar")
 }
 
 // Defer the definition of the dependencies to the end

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation("com.github.outsystems:oscore-android:1.1.0@aar")
   implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
   //TODO Update library version for to match the last camera lib android before release
-  implementation("com.github.outsystems:oscamera-android:0.0.20.2@aar")
+  implementation("com.github.outsystems:oscamera-android:0.0.20.3@aar")
 }
 
 // Defer the definition of the dependencies to the end

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation("com.github.outsystems:oscore-android:1.1.0@aar")
   implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
   //TODO Update library version for to match the last camera lib android before release
-  implementation("com.github.outsystems:oscamera-android:0.0.20.4@aar")
+  implementation("com.github.outsystems:oscamera-android:0.0.20.7@aar")
 }
 
 // Defer the definition of the dependencies to the end

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -591,8 +591,8 @@ class CameraLauncher : CordovaPlugin() {
                 // Check if intent and data (Uri) are not null
                 val uri = intent?.data
                 if (uri == null) {
-                    sendError(OSCAMRError.CAPTURE_VIDEO_ERROR)
-                    return
+                    val fromPreferences = cordova.activity.getSharedPreferences("CameraStore", Context.MODE_PRIVATE).getString("CameraStore", "")
+                    fromPreferences.let {  uri = Uri.parse(fromPreferences) }
                 }
                 if(cordova.activity == null) {
                     sendError(OSCAMRError.CONTEXT_ERROR)

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -592,7 +592,7 @@ class CameraLauncher : CordovaPlugin() {
                 // Check if intent and data (Uri) are not null
                 var uri = intent?.data
                 if (uri == null) {
-                    val fromPreferences = cordova.activity.getSharedPreferences(STORE, Context.MODE_PRIVATE).getString("CameraStore", "")
+                    val fromPreferences = cordova.activity.getSharedPreferences(STORE, Context.MODE_PRIVATE).getString(STORE, "")
                     fromPreferences.let {  uri = Uri.parse(fromPreferences) }
                 }
                 if(cordova.activity == null) {

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -20,6 +20,7 @@ package org.apache.cordova.camera
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.database.Cursor
@@ -589,9 +590,9 @@ class CameraLauncher : CordovaPlugin() {
         } else if (requestCode == OSCAMRMediaHelper.REQUEST_VIDEO_CAPTURE || requestCode == OSCAMRMediaHelper.REQUEST_VIDEO_CAPTURE_SAVE_TO_GALLERY) {
             if (resultCode == Activity.RESULT_OK) {
                 // Check if intent and data (Uri) are not null
-                val uri = intent?.data
+                var uri = intent?.data
                 if (uri == null) {
-                    val fromPreferences = cordova.activity.getSharedPreferences("CameraStore", Context.MODE_PRIVATE).getString("CameraStore", "")
+                    val fromPreferences = cordova.activity.getSharedPreferences(STORE, Context.MODE_PRIVATE).getString("CameraStore", "")
                     fromPreferences.let {  uri = Uri.parse(fromPreferences) }
                 }
                 if(cordova.activity == null) {
@@ -813,6 +814,8 @@ class CameraLauncher : CordovaPlugin() {
 
         private const val CHOOSE_FROM_GALLERY_REQUEST_CODE = 869456849
         private const val CHOOSE_FROM_GALLERY_PERMISSION_CODE = 869454849
+
+        private const val STORE = "CameraStore"
 
         private fun createPermissionArray(): Array<String> {
             return if (Build.VERSION.SDK_INT < 33) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR fixes an issue when the intent returned after recording a video is null (and the video is saved in the cache).

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2403

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 9 and 8 builds.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
