### PR TITLE
RMET-2346 ::: Multimedia metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+- [Bridge] Add `include Metadata` client action input parameter (https://outsystemsrd.atlassian.net/browse/RMET-2346).
 
 ### Features
 - [Bridge] Add `Play Video` client action (https://outsystemsrd.atlassian.net/browse/RMET-2361).

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -204,7 +204,7 @@ cameraExport.recordVideo = function(successCallback, errorCallback, options) {
     argscheck.checkArgs('fFO', 'Camera.recordVideo', arguments);
     options = options || {};
 
-    var saveToGallery = !!options.saveToGallery;
+    let saveToGallery = !!options.saveToGallery;
     let includeMetadata = !!options.includeMetadata;
 
     var args = [{saveToGallery, includeMetadata}];

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -205,12 +205,12 @@ cameraExport.recordVideo = function(successCallback, errorCallback, options) {
     options = options || {};
 
     var saveToGallery = !!options.saveToGallery;
+    let includeMetadata = !!options.includeMetadata;
 
-    var args = [saveToGallery];
+    var args = [{saveToGallery, includeMetadata}];
 
     exec(successCallback, errorCallback, 'Camera', 'recordVideo', args);
 }
-
 
 cameraExport.chooseFromGallery = function(successCallback, errorCallback, options){
     argscheck.checkArgs('fFO', 'Camera.chooseFromGallery', arguments);
@@ -218,8 +218,9 @@ cameraExport.chooseFromGallery = function(successCallback, errorCallback, option
 
     let mediaType = options.mediaType;
     let allowMultipleSelection = !!options.allowMultipleSelection;
+    let includeMetadata = !!options.includeMetadata;
 
-    let args = [{mediaType, allowMultipleSelection}];
+    let args = [{mediaType, allowMultipleSelection, includeMetadata}];
 
     exec(successCallback, errorCallback, 'Camera', 'chooseFromGallery', args);
 }


### PR DESCRIPTION
## Description
- Adds a new flag `includeMetadata` indicating this method should return the media metadata for that item.
- Refactors `recordVideo` args to send a json object instead of array.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2346

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [X] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [X] iOS
- [X] JavaScript

## Tests
Tested under emulation and debugger.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly