### PR TITLE
Parallel E2E test execution and splits the pipeline into different jobs

### DIFF
--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -1,4 +1,4 @@
-name: "E2E UI Test"
+name: "Camera Plugin ODC Pipeline"
 
 pr: none
 trigger:
@@ -29,6 +29,7 @@ stages:
       - group: "Saucelabs User Variables"
     jobs:
       - job: update_wrapper
+        displayName: "Update the plugin wrapper"
         steps:
           - checkout: self
           - checkout: MobilePluginsODCPipeline
@@ -41,6 +42,7 @@ stages:
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsODCPipeline
       - job: update_sampleapp
         dependsOn: update_wrapper
+        displayName: "Refresh dependencies on the Sample App, deploy to QA and build packages"
         steps:
           - checkout: self
           - checkout: MobilePluginsODCPipeline
@@ -90,6 +92,7 @@ stages:
             displayName: "Set SauceLabs Storage IDs variables"
       - job: android_e2e_tests
         dependsOn: update_sampleapp
+        displayName: "Android E2E tests"
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests
@@ -108,6 +111,7 @@ stages:
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
       - job: iOS_e2e_tests
         dependsOn: update_sampleapp
+        displayName: "iOS E2E tests"
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -81,8 +81,10 @@ stages:
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests/
             continueOnError: true
           - script: |
-              echo "APK: $apkPath | $(apkPath)"
-              echo "IPA: $ipaPath | $(ipaPath)"
+              echo "APK: $(apkPath)"
+              ls -la $(apkPath)
+              echo "IPA: $(ipaPath)"
+              ls -la $(ipaPath)
               node ./scripts/upload_application.js -- -f $(apkPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid
               node ./scripts/upload_application.js -- -f $(ipaPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid            
             workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -28,14 +28,10 @@ stages:
       - group: "Camera Plugin Variables"
       - group: "Saucelabs User Variables"
     jobs:
-      - job: checkout_repos
+      - job: update_wrapper
         steps:
           - checkout: self
-          - checkout: MobilePluginsE2ETests
           - checkout: MobilePluginsODCPipeline
-      - job: update_wrapper
-        dependsOn: checkout_repos
-        steps:
           - template: build/ci/update-wrapper.yaml@MobilePluginsODCPipeline
             parameters:
               secretFileName: "eng-osrd-mobile-neo1-StampsInformation.json"
@@ -46,6 +42,8 @@ stages:
       - job: update_sampleapp
         dependsOn: update_wrapper
         steps:
+          - checkout: self
+          - checkout: MobilePluginsODCPipeline        
           - template: build/ci/refresh-sampleapp.yaml@MobilePluginsODCPipeline
             parameters:
               secretFileName: "eng-osrd-mobile-neo1-StampsInformation.json"
@@ -61,6 +59,8 @@ stages:
       - job: upload_built_apps
         dependsOn: update_sampleapp
         steps:
+          - checkout: self
+          - checkout: MobilePluginsE2ETests
           - task: NodeTool@0
             displayName: "Use Node 14.15.4"
             inputs:
@@ -91,6 +91,8 @@ stages:
       - job: android_e2e_tests
         dependsOn: upload_built_apps
         steps:
+          - checkout: self
+          - checkout: MobilePluginsE2ETests        
           - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
             parameters:
               PACKAGE: $(ANDROID_PACKAGE_ID)
@@ -109,6 +111,8 @@ stages:
       - job: iOS_e2e_tests
         dependsOn: upload_built_apps
         steps:
+          - checkout: self
+          - checkout: MobilePluginsE2ETests        
           - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
             parameters:
               PACKAGE: $(IOS_BUNDLE_ID)

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -56,10 +56,14 @@ stages:
               cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path
             name: set_path_vars
             displayName: "Set package variables"
-          - publish: $(apkPath)
-            artifact: CameraSampleAppAndroid
-          - publish: $(ipaPath)
-            artifact: CameraSampleAppiOS
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: $(apkPath)
+              artifact: CameraSampleAppAndroid
+          - task: PublishPipelineArtifact@1
+            inputs:
+              targetPath: $(apkPath)
+              artifact: CameraSampleAppiOS
       - job: upload_built_apps
         dependsOn: update_sampleapp
         variables:

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -78,14 +78,16 @@ stages:
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests/
             continueOnError: true
           - script: |
+              echo "APK: $apkPath | $(apkPath)"
+              echo "IPA: $ipaPath | $(ipaPath)"
               node ./scripts/upload_application.js -- -f $(apkPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid
               node ./scripts/upload_application.js -- -f $(ipaPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid
+            env:
+              apkPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.apkPath'] ]
+              ipaPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.ipaPath'] ]              
             workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
             name: upload_packages
             displayName: "Upload package to SauceLabs"
-            env:
-              apkPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.apkPath'] ]
-              ipaPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.ipaPath'] ]
           - script: |
               echo "##vso[task.setvariable variable=androidSLID;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid)"
               echo "##vso[task.setvariable variable=iosSLID;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid)"

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -93,6 +93,9 @@ stages:
       - job: android_e2e_tests
         dependsOn: update_sampleapp
         displayName: "Android E2E tests"
+        variables:
+          - name: storageID
+            value: $[ dependencies.upload_built_apps.outputs['set_slid_vars.androidSLID'] ]        
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests
@@ -107,11 +110,14 @@ stages:
               RETRY: 1
               TEST_TYPE: native
               THREADS: 3
-              STORAGE_ID: "$[ dependencies.upload_built_apps.outputs['set_slid_vars.androidSLID'] ]"
+              STORAGE_ID: $(storageID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
       - job: iOS_e2e_tests
         dependsOn: update_sampleapp
         displayName: "iOS E2E tests"
+        variables:
+          - name: storageID
+            value: $[ dependencies.upload_built_apps.outputs['set_slid_vars.iosSLID'] ]
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests
@@ -125,5 +131,5 @@ stages:
               RETRY: 1
               TEST_TYPE: native
               THREADS: 3
-              STORAGE_ID: "$[ dependencies.upload_built_apps.outputs['set_slid_vars.iosSLID'] ]"
+              STORAGE_ID: $(storageID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -95,7 +95,7 @@ stages:
         displayName: "Android E2E tests"
         variables:
           - name: storageID
-            value: $[ dependencies.upload_built_apps.outputs['set_slid_vars.androidSLID'] ]        
+            value: $[ dependencies.update_sampleapp.outputs['set_slid_vars.androidSLID'] ]        
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests
@@ -117,7 +117,7 @@ stages:
         displayName: "iOS E2E tests"
         variables:
           - name: storageID
-            value: $[ dependencies.upload_built_apps.outputs['set_slid_vars.iosSLID'] ]
+            value: $[ dependencies.update_sampleapp.outputs['set_slid_vars.iosSLID'] ]
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -58,6 +58,9 @@ stages:
             displayName: "Set package variables"
       - job: upload_built_apps
         dependsOn: update_sampleapp
+        variables:
+          apkPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.apkPath'] ]
+          ipaPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.ipaPath'] ]  
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests
@@ -81,10 +84,7 @@ stages:
               echo "APK: $apkPath | $(apkPath)"
               echo "IPA: $ipaPath | $(ipaPath)"
               node ./scripts/upload_application.js -- -f $(apkPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid
-              node ./scripts/upload_application.js -- -f $(ipaPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid
-            env:
-              apkPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.apkPath'] ]
-              ipaPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.ipaPath'] ]              
+              node ./scripts/upload_application.js -- -f $(ipaPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid            
             workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
             name: upload_packages
             displayName: "Upload package to SauceLabs"

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -95,8 +95,6 @@ stages:
           - checkout: MobilePluginsE2ETests        
           - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
             parameters:
-              PACKAGE: $(ANDROID_PACKAGE_ID)
-              MABS: 9
               DATACENTER: eu
               DEVICE: "samsung or google"
               DEVICE_PLATFORM: Android
@@ -115,8 +113,6 @@ stages:
           - checkout: MobilePluginsE2ETests        
           - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
             parameters:
-              PACKAGE: $(IOS_BUNDLE_ID)
-              MABS: 9
               DATACENTER: eu
               DEVICE_PLATFORM: iOS
               DEVICE_VERSION: 16

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -51,9 +51,9 @@ stages:
               SAMPLEAPP_APP_KEY: "3c0451ef-0d99-4e09-adb5-718e009deb9d"
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsODCPipeline
           - script: |
-              echo "##vso[task.setvariable variable=apkPath;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk-path)"
+              echo "##vso[task.setvariable variable=apkPath]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk-path)"
               cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk-path
-              echo "##vso[task.setvariable variable=ipaPath;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path)"
+              echo "##vso[task.setvariable variable=ipaPath]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path)"
               cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path
             name: set_path_vars
             displayName: "Set package variables"         

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -58,7 +58,7 @@ stages:
             displayName: "Set package variables"
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: '$(apkPath)'
+              targetPath: "$(apkPath)"
               artifact: CameraSampleAppAndroid
           - publish: '$(ipaPath)'
             artifact: CameraSampleAppiOS

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -18,7 +18,7 @@ resources:
       endpoint: OutSystems
     - repository: MobilePluginsODCPipeline
       type: github
-      ref: main
+      ref: fix/StampsLocation
       name: OutSystems/MobilePluginsODCPipeline
       endpoint: OutSystems
 

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -89,7 +89,7 @@ stages:
             name: set_slid_vars
             displayName: "Set SauceLabs Storage IDs variables"
       - job: android_e2e_tests
-        dependsOn: upload_built_apps
+        dependsOn: update_sampleapp
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests
@@ -107,7 +107,7 @@ stages:
               STORAGE_ID: $[ dependencies.upload_built_apps.outputs['set_slid_vars.androidSLID'] ]
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
       - job: iOS_e2e_tests
-        dependsOn: upload_built_apps
+        dependsOn: update_sampleapp
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -43,16 +43,16 @@ stages:
         dependsOn: update_wrapper
         steps:
           - checkout: self
-          - checkout: MobilePluginsODCPipeline        
+          - checkout: MobilePluginsODCPipeline
           - template: build/ci/refresh-sampleapp.yaml@MobilePluginsODCPipeline
             parameters:
               secretFileName: "eng-osrd-mobile-neo1-StampsInformation.json"
               SAMPLEAPP_APP_KEY: "3c0451ef-0d99-4e09-adb5-718e009deb9d"
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsODCPipeline
           - script: |
-              echo "##vso[task.setvariable variable=apkPath]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk-path)"
+              echo "##vso[task.setvariable variable=apkPath;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk-path)"
               cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk-path
-              echo "##vso[task.setvariable variable=ipaPath]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path)"
+              echo "##vso[task.setvariable variable=ipaPath;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path)"
               cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path
             name: set_path_vars
             displayName: "Set package variables"
@@ -83,16 +83,19 @@ stages:
             workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
             name: upload_packages
             displayName: "Upload package to SauceLabs"
+            env:
+              apkPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.apkPath'] ]
+              ipaPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.ipaPath'] ]
           - script: |
-              echo "##vso[task.setvariable variable=androidSLID]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid)"
-              echo "##vso[task.setvariable variable=iosSLID]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid)"
+              echo "##vso[task.setvariable variable=androidSLID;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid)"
+              echo "##vso[task.setvariable variable=iosSLID;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid)"
             name: set_slid_vars
             displayName: "Set SauceLabs Storage IDs variables"
       - job: android_e2e_tests
         dependsOn: upload_built_apps
         steps:
           - checkout: self
-          - checkout: MobilePluginsE2ETests        
+          - checkout: MobilePluginsE2ETests
           - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
             parameters:
               DATACENTER: eu
@@ -104,13 +107,13 @@ stages:
               RETRY: 1
               TEST_TYPE: native
               THREADS: 3
-              STORAGE_ID: $(androidSLID)
+              STORAGE_ID: $[ dependencies.upload_built_apps.outputs['set_slid_vars.androidSLID'] ]
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
       - job: iOS_e2e_tests
         dependsOn: upload_built_apps
         steps:
           - checkout: self
-          - checkout: MobilePluginsE2ETests        
+          - checkout: MobilePluginsE2ETests
           - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
             parameters:
               DATACENTER: eu
@@ -121,5 +124,5 @@ stages:
               RETRY: 1
               TEST_TYPE: native
               THREADS: 3
-              STORAGE_ID: $(iosSLID)
+              STORAGE_ID: $[ dependencies.upload_built_apps.outputs['set_slid_vars.iosSLID'] ]
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -104,7 +104,7 @@ stages:
               RETRY: 1
               TEST_TYPE: native
               THREADS: 3
-              STORAGE_ID: $[ dependencies.upload_built_apps.outputs['set_slid_vars.androidSLID'] ]
+              STORAGE_ID: "$[ dependencies.upload_built_apps.outputs['set_slid_vars.androidSLID'] ]"
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
       - job: iOS_e2e_tests
         dependsOn: update_sampleapp
@@ -121,5 +121,5 @@ stages:
               RETRY: 1
               TEST_TYPE: native
               THREADS: 3
-              STORAGE_ID: $[ dependencies.upload_built_apps.outputs['set_slid_vars.iosSLID'] ]
+              STORAGE_ID: "$[ dependencies.upload_built_apps.outputs['set_slid_vars.iosSLID'] ]"
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -33,6 +33,9 @@ stages:
           - checkout: self
           - checkout: MobilePluginsE2ETests
           - checkout: MobilePluginsODCPipeline
+      - job: update_wrapper
+        dependsOn: checkout_repos
+        steps:
           - template: build/ci/update-wrapper.yaml@MobilePluginsODCPipeline
             parameters:
               secretFileName: "eng-osrd-mobile-neo1-StampsInformation.json"
@@ -40,6 +43,9 @@ stages:
               PLUGIN_UPDATE_URL: "https://github.com/OutSystems/cordova-plugin-camera#$(Build.SourceBranchName)"
               PLUGIN_UPDATE_VERSION: "$(Build.SourceBranchName)"
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsODCPipeline
+      - job: update_sampleapp
+        dependsOn: update_wrapper
+        steps:
           - template: build/ci/refresh-sampleapp.yaml@MobilePluginsODCPipeline
             parameters:
               secretFileName: "eng-osrd-mobile-neo1-StampsInformation.json"
@@ -52,22 +58,25 @@ stages:
               cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path
             name: set_path_vars
             displayName: "Set package variables"
+      - job: upload_built_apps
+        dependsOn: update_sampleapp
+        steps:
           - task: NodeTool@0
-            displayName: 'Use Node 14.15.4'
+            displayName: "Use Node 14.15.4"
             inputs:
-              versionSpec: '14.15.4'
+              versionSpec: "14.15.4"
               checkLatest: true
           - task: npmAuthenticate@0
-            displayName: 'npm Authenticate .npmrc'
+            displayName: "npm Authenticate .npmrc"
             inputs:
-              workingFile: '$(System.DefaultWorkingDirectory)/MobilePluginsE2ETests/.npmrc'
+              workingFile: "$(System.DefaultWorkingDirectory)/MobilePluginsE2ETests/.npmrc"
           - task: CmdLine@2
             name: install_dep_cp2
-            displayName: 'Install dependencies using yarn'
+            displayName: "Install dependencies using yarn"
             inputs:
-              script: 'yarn'
+              script: "yarn"
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests/
-            continueOnError: true    
+            continueOnError: true
           - script: |
               node ./scripts/upload_application.js -- -f $(apkPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid
               node ./scripts/upload_application.js -- -f $(ipaPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid
@@ -79,6 +88,9 @@ stages:
               echo "##vso[task.setvariable variable=iosSLID]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid)"
             name: set_slid_vars
             displayName: "Set SauceLabs Storage IDs variables"
+      - job: android_e2e_tests
+        dependsOn: upload_built_apps
+        steps:
           - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
             parameters:
               PACKAGE: $(ANDROID_PACKAGE_ID)
@@ -94,6 +106,9 @@ stages:
               THREADS: 3
               STORAGE_ID: $(androidSLID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
+      - job: iOS_e2e_tests
+        dependsOn: upload_built_apps
+        steps:
           - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
             parameters:
               PACKAGE: $(IOS_BUNDLE_ID)
@@ -108,6 +123,3 @@ stages:
               THREADS: 3
               STORAGE_ID: $(iosSLID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
-
-
-              

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -44,6 +44,7 @@ stages:
         steps:
           - checkout: self
           - checkout: MobilePluginsODCPipeline
+          - checkout: MobilePluginsE2ETests
           - template: build/ci/refresh-sampleapp.yaml@MobilePluginsODCPipeline
             parameters:
               secretFileName: "eng-osrd-mobile-neo1-StampsInformation.json"
@@ -55,31 +56,7 @@ stages:
               echo "##vso[task.setvariable variable=ipaPath;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path)"
               cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path
             name: set_path_vars
-            displayName: "Set package variables"
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: "$(apkPath)"
-              artifact: CameraSampleAppAndroid
-          - publish: '$(ipaPath)'
-            artifact: CameraSampleAppiOS
-      - job: upload_built_apps
-        dependsOn: update_sampleapp
-        variables:
-          apkPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.apkPath'] ]
-          ipaPath: $[ dependencies.update_sampleapp.outputs['set_path_vars.ipaPath'] ]  
-        steps:
-          - checkout: self
-          - checkout: MobilePluginsE2ETests
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Android Sample App'
-            inputs:
-              artifact: 'CameraSampleAppAndroid'
-              path: $(Pipeline.Workspace)
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download iOS Sample App'
-            inputs:
-              artifact: 'CameraSampleAppiOS'
-              path: $(Pipeline.Workspace)              
+            displayName: "Set package variables"         
           - task: NodeTool@0
             displayName: "Use Node 14.15.4"
             inputs:
@@ -97,12 +74,12 @@ stages:
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests/
             continueOnError: true
           - script: |
-              echo "APK: $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk"
-              ls -la $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk
-              echo "IPA: $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa"
-              ls -la $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa
-              node ./scripts/upload_application.js -- -f $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid
-              node ./scripts/upload_application.js -- -f $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid            
+              echo "APK: $(apkPath)"
+              ls -la $(ipaPath)
+              echo "IPA: $(ipaPath)"
+              ls -la $(ipaPath)
+              node ./scripts/upload_application.js -- -f $(apkPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid
+              node ./scripts/upload_application.js -- -f $(ipaPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid
             workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
             name: upload_packages
             displayName: "Upload package to SauceLabs"

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -56,6 +56,10 @@ stages:
               cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa-path
             name: set_path_vars
             displayName: "Set package variables"
+          - publish: $(apkPath)
+            artifact: CameraSampleAppAndroid
+          - publish: $(ipaPath)
+            artifact: CameraSampleAppiOS
       - job: upload_built_apps
         dependsOn: update_sampleapp
         variables:
@@ -64,6 +68,16 @@ stages:
         steps:
           - checkout: self
           - checkout: MobilePluginsE2ETests
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Android Sample App'
+            inputs:
+              artifact: 'CameraSampleAppAndroid'
+              path: $(Pipeline.Workspace)
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download iOS Sample App'
+            inputs:
+              artifact: 'CameraSampleAppiOS'
+              path: $(Pipeline.Workspace)              
           - task: NodeTool@0
             displayName: "Use Node 14.15.4"
             inputs:
@@ -81,12 +95,12 @@ stages:
               workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests/
             continueOnError: true
           - script: |
-              echo "APK: $(apkPath)"
-              ls -la $(apkPath)
-              echo "IPA: $(ipaPath)"
-              ls -la $(ipaPath)
-              node ./scripts/upload_application.js -- -f $(apkPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid
-              node ./scripts/upload_application.js -- -f $(ipaPath) -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid            
+              echo "APK: $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk"
+              ls -la $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk
+              echo "IPA: $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa"
+              ls -la $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa
+              node ./scripts/upload_application.js -- -f $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.apk -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.android-slid
+              node ./scripts/upload_application.js -- -f $(Pipeline.Workspace)/3c0451ef-0d99-4e09-adb5-718e009deb9d.ipa -o /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid            
             workingDirectory: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
             name: upload_packages
             displayName: "Upload package to SauceLabs"

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -18,7 +18,7 @@ resources:
       endpoint: OutSystems
     - repository: MobilePluginsODCPipeline
       type: github
-      ref: fix/StampsLocation
+      ref: main
       name: OutSystems/MobilePluginsODCPipeline
       endpoint: OutSystems
 

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -58,12 +58,10 @@ stages:
             displayName: "Set package variables"
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: $(apkPath)
+              targetPath: '$(apkPath)'
               artifact: CameraSampleAppAndroid
-          - task: PublishPipelineArtifact@1
-            inputs:
-              targetPath: $(apkPath)
-              artifact: CameraSampleAppiOS
+          - publish: '$(ipaPath)'
+            artifact: CameraSampleAppiOS
       - job: upload_built_apps
         dependsOn: update_sampleapp
         variables:


### PR DESCRIPTION
### Description
This includes both RMET-2366 and RMET-2367, splitting the one Azure pipeline job we had into several ones to help on debugging and also enabling parallel execution for the E2E functional tests.
This reduces the execution time in about 5 minutes.

### Testing

Execution at https://dev.azure.com/OutSystemsRD/Mobile%20Supported%20Plugins/_build/results?buildId=698961&view=results


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
