### PR TITLE
RMET-2472 Camera Plugin - Request for gallery permissions if saveToGallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+- [Android] Ask for gallery permissions for RecordVideo (https://outsystemsrd.atlassian.net/browse/RMET-2472).
 - [Android] Update Error Codes and Error Messages (https://outsystemsrd.atlassian.net/browse/RMET-2400).
 - [Android] Add compression to big images (https://outsystemsrd.atlassian.net/browse/RMET-2409).
 - [iOS] Update Error Codes and Error Messages (https://outsystemsrd.atlassian.net/browse/RMET-2400).

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
   implementation("com.github.outsystems:oscore-android:1.1.0@aar")
   implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
-  implementation("com.github.outsystems:oscamera-android:0.0.22@aar")
+  implementation("com.github.outsystems:oscamera-android:0.0.23@aar")
 }
 
 // Defer the definition of the dependencies to the end

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -360,10 +360,49 @@ class CameraLauncher : CordovaPlugin() {
 
     fun callCaptureVideo(saveVideoToGallery: Boolean) {
 
-        if (!PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)) {
-            PermissionHelper.requestPermission(this, CAPTURE_VIDEO_SEC, Manifest.permission.CAMERA)
+        val cameraPermissionNeeded = !PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)
+
+        val galleryPermissionNeeded = saveVideoToGallery && !((Build.VERSION.SDK_INT < 33 &&
+                PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
+                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) ||
+                (Build.VERSION.SDK_INT >= 33 &&
+                        PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO) &&
+                        PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES)))
+
+        if (cameraPermissionNeeded && galleryPermissionNeeded) {
+            PermissionHelper.requestPermissions(this, CAPTURE_VIDEO_SEC, permissions)
             return
         }
+
+        else if (cameraPermissionNeeded) {
+            PermissionHelper.requestPermission(
+                this,
+                CAPTURE_VIDEO_SEC,
+                Manifest.permission.CAMERA
+            )
+            return
+        }
+        else if (galleryPermissionNeeded) {
+            if (Build.VERSION.SDK_INT < 33) {
+                PermissionHelper.requestPermissions(
+                    this,
+                    CAPTURE_VIDEO_SEC,
+                    arrayOf(
+                        Manifest.permission.READ_EXTERNAL_STORAGE,
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE
+                    )
+                )
+            }
+            else {
+                PermissionHelper.requestPermissions(
+                    this,
+                    CAPTURE_VIDEO_SEC,
+                    arrayOf(READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)
+                )
+            }
+            return
+        }
+
         cordova.setActivityResultCallback(this)
         camController?.captureVideo(cordova.activity, saveVideoToGallery) {
             sendError(it)

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -119,6 +119,8 @@ class CameraLauncher : CordovaPlugin() {
             OSCAMRImageHelper()
         )
 
+        camController?.deleteVideoFilesFromCache(cordova.activity)
+
     }
 
     override fun onDestroy() {
@@ -666,6 +668,7 @@ class CameraLauncher : CordovaPlugin() {
                     sendError(OSCAMRError.CAPTURE_VIDEO_ERROR)
                     return
                 }
+                cordova.activity.getSharedPreferences(STORE, Context.MODE_PRIVATE).edit().remove(STORE).apply()
 
                 CoroutineScope(Dispatchers.Default).launch {
                     camController?.processResultFromVideo(

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -668,7 +668,6 @@ class CameraLauncher : CordovaPlugin() {
                     sendError(OSCAMRError.CAPTURE_VIDEO_ERROR)
                     return
                 }
-                cordova.activity.getSharedPreferences(STORE, Context.MODE_PRIVATE).edit().remove(STORE).apply()
 
                 CoroutineScope(Dispatchers.Default).launch {
                     camController?.processResultFromVideo(


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Adds code to ask for gallery permissions if `SaveToGallery = true`.
- This PR also includes deleting cached files in the `pluginInitialize` method, to make sure previously cached files are deleted once the plugin is called.


## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2472


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested on Android 12 device.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
