### PR TITLE
RMET-2350 :: Bridge :: Add includeMetadata to take picture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### Features
+- [Bridge] Add `include Metadata` to `TakePicture` (https://outsystemsrd.atlassian.net/browse/RMET-2350).
+
 ## [4.2.0-OS41]
 
 ### Features

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -163,17 +163,19 @@ class CameraLauncher : CordovaPlugin() {
                 mediaType = PICTURE
                 mQuality = 50
 
+                val parameters = args.getJSONObject(0)
                 //Take the values from the arguments if they're not already defined (this is tricky)
-                mQuality = args.getInt(0)
-                targetWidth = args.getInt(1)
-                targetHeight = args.getInt(2)
-                encodingType = args.getInt(3)
-                allowEdit = args.getBoolean(4)
-                correctOrientation = args.getBoolean(5)
-                saveToPhotoAlbum = args.getBoolean(6)
-                destType = args.getInt(8)
-                srcType = args.getInt(9)
-                mediaType = args.getInt(10)
+                mQuality = parameters.getInt(QUALITY)
+                targetWidth = parameters.getInt(WIDTH)
+                targetHeight = parameters.getInt(HEIGHT)
+                encodingType = parameters.getInt(ENCODING_TYPE)
+                allowEdit = parameters.getBoolean(ALLOW_EDIT)
+                correctOrientation = parameters.getBoolean(CORRECT_ORIENTATION)
+                saveToPhotoAlbum = parameters.getBoolean(SAVE_TO_ALBUM)
+                destType = parameters.getInt(DEST_TYPE)
+                srcType = parameters.getInt(SOURCE_TYPE)
+                mediaType = parameters.getInt(MEDIA_TYPE)
+                includeMetadata = parameters.getBoolean(INCLUDE_METADATA)
 
                 // If the user specifies a 0 or smaller width/height
                 // make it -1 so later comparisons succeed
@@ -889,6 +891,18 @@ class CameraLauncher : CordovaPlugin() {
         private const val INCLUDE_METADATA = "includeMetadata"
         private const val ALLOW_MULTIPLE = "allowMultipleSelection"
         private const val MEDIA_TYPE = "mediaType"
+
+        //take picture json
+        private const val QUALITY = "quality"
+        private const val WIDTH = "targetWidth"
+        private const val HEIGHT = "targetHeight"
+        private const val ENCODING_TYPE = "encodingType"
+        private const val ALLOW_EDIT = "allowEdit"
+        private const val CORRECT_ORIENTATION = "correctOrientation"
+        private const val SAVE_TO_ALBUM = "saveToPhotoAlbum"
+        private const val SOURCE_TYPE = "sourceType"
+        private const val CAMERA_DIRECTION = "caneraDirection"
+        private const val DEST_TYPE = "destinationType"
 
         private fun createPermissionArray(): Array<String> {
             return if (Build.VERSION.SDK_INT < 33) {

--- a/src/ios/OSCAMRParametersStruct.swift
+++ b/src/ios/OSCAMRParametersStruct.swift
@@ -89,3 +89,36 @@ extension OSCAMRVideoOptions {
         self.init(saveToPhotoAlbum: parameters.saveToGallery, returnMetadata: parameters.includeMetadata)
     }
 }
+
+struct OSCAMRPictureParameters: Decodable {
+    let quality: Int
+    let targetWidth: Int
+    let targetHeight: Int
+    let encodingType: Int
+    let sourceType: Int
+    let allowEdit: Bool
+    let correctOrientation: Bool
+    let saveToPhotoAlbum: Bool
+    let cameraDirection: Int 
+    let includeMetadata: Bool
+}
+
+extension OSCAMRPictureOptions {
+    convenience init(from parameters: OSCAMRPictureParameters) {
+        var targetSize = OSCAMRSize(width: parameters.targetWidth, height: parameters.targetHeight)
+        let encodingType = OSCAMREncodingType(rawValue: parameters.encodingType) ?? .jpeg
+        let direction = OSCAMRDirection(rawValue: parameters.cameraDirection) ?? .back
+
+        self.init(
+            quality: parameters.quality, 
+            size: targetSize, 
+            correctOrientation: parameters.correctOrientation, 
+            encodingType: encodingType, 
+            saveToPhotoAlbum: parameters.saveToPhotoAlbum, 
+            direction: direction, 
+            allowEdit: parameters.allowEdit, 
+            returnMetadata: parameters.includeMetadata
+        )
+        
+    }
+}

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -134,23 +134,23 @@ for (var key in Camera) {
 cameraExport.getPicture = function (successCallback, errorCallback, options) {
     argscheck.checkArgs('fFO', 'Camera.getPicture', arguments);
     options = options || {};
-    var getValue = argscheck.getValue;
+    let getValue = argscheck.getValue;
 
-    var quality = getValue(options.quality, 50);
-    var destinationType = getValue(options.destinationType, Camera.DestinationType.FILE_URI);
-    var sourceType = getValue(options.sourceType, Camera.PictureSourceType.CAMERA);
-    var targetWidth = getValue(options.targetWidth, -1);
-    var targetHeight = getValue(options.targetHeight, -1);
-    var encodingType = getValue(options.encodingType, Camera.EncodingType.JPEG);
-    var mediaType = getValue(options.mediaType, Camera.MediaType.PICTURE);
-    var allowEdit = !!options.allowEdit;
-    var correctOrientation = !!options.correctOrientation;
-    var saveToPhotoAlbum = !!options.saveToPhotoAlbum;
-    var popoverOptions = getValue(options.popoverOptions, null);
-    var cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+    let quality = getValue(options.quality, 50);
+    let sourceType = getValue(options.sourceType, Camera.PictureSourceType.CAMERA);
+    let destinationType = getValue(options.destinationType, Camera.DestinationType.FILE_URI);
+    let targetWidth = getValue(options.targetWidth, -1);
+    let targetHeight = getValue(options.targetHeight, -1);
+    let encodingType = getValue(options.encodingType, Camera.EncodingType.JPEG);
+    let mediaType = getValue(options.mediaType, Camera.MediaType.PICTURE);
+    let allowEdit = !!options.allowEdit;
+    let correctOrientation = !!options.correctOrientation;
+    let saveToPhotoAlbum = !!options.saveToPhotoAlbum;
+    let cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
 
-    var args = [quality, targetWidth, targetHeight, encodingType, allowEdit, correctOrientation, 
-        saveToPhotoAlbum, cameraDirection, destinationType, sourceType, mediaType, popoverOptions];
+
+    let args = [{quality, targetWidth, targetHeight, encodingType, allowEdit, correctOrientation, 
+        saveToPhotoAlbum, cameraDirection, destinationType, sourceType, mediaType}];
 
     exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
     // XXX: commented out
@@ -235,5 +235,32 @@ cameraExport.playVideo = function(successCallback, errorCallback, options){
 
     exec(successCallback, errorCallback, 'Camera', 'playVideo', args);
 }
+
+cameraExport.takePicture = function (successCallback, errorCallback, options) {
+    argscheck.checkArgs('fFO', 'Camera.getPicture', arguments);
+    options = options || {};
+    let getValue = argscheck.getValue;
+
+    let quality = getValue(options.quality, 50);
+    let sourceType = getValue(options.sourceType, Camera.PictureSourceType.CAMERA);
+    let destinationType = getValue(options.destinationType, Camera.DestinationType.FILE_URI);
+    let targetWidth = getValue(options.targetWidth, -1);
+    let targetHeight = getValue(options.targetHeight, -1);
+    let encodingType = getValue(options.encodingType, Camera.EncodingType.JPEG);
+    let mediaType = getValue(options.mediaType, Camera.MediaType.PICTURE);
+    let allowEdit = !!options.allowEdit;
+    let correctOrientation = !!options.correctOrientation;
+    let saveToPhotoAlbum = !!options.saveToPhotoAlbum;
+    let cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
+    let includeMetadata = !!options.includeMetadata;
+
+
+    let args = [{quality, targetWidth, targetHeight, encodingType, allowEdit, correctOrientation, 
+        saveToPhotoAlbum, cameraDirection, destinationType, sourceType, mediaType, includeMetadata}];
+
+    exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
+    // XXX: commented out
+    // return new CameraPopoverHandle();
+};
 
 module.exports = cameraExport;


### PR DESCRIPTION
## Description

- Adds new input parameter to `getPicture` function
- Changes from `var`to `let`in variables, to follow best practices

## Context
For more context check this [JIRA issue](https://outsystemsrd.atlassian.net/browse/RMET-2350) 


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [x] JavaScript

## Tests
No tests can be done. Needs native implementation

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
