### PR TITLE
Feat/rmet 2560

### DIFF
--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -92,6 +92,7 @@ stages:
             displayName: "Set SauceLabs Storage IDs variables"
       - job: android_e2e_tests_P0s
         displayName: "Android E2E P0 tests"
+        dependsOn: update_sampleapp
         continueOnError: false
         variables:
           - name: storageID
@@ -138,6 +139,7 @@ stages:
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
       - job: iOS_e2e_tests_P0s
         displayName: "iOS E2E P0 tests"
+        dependsOn: update_sampleapp
         continueOnError: false
         variables:
           - name: storageID

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -90,9 +90,10 @@ stages:
               echo "##vso[task.setvariable variable=iosSLID;isOutput=true]$(cat /tmp/3c0451ef-0d99-4e09-adb5-718e009deb9d.ios-slid)"
             name: set_slid_vars
             displayName: "Set SauceLabs Storage IDs variables"
-      - job: android_e2e_tests
+      - job: android_e2e_tests_P0s
         dependsOn: update_sampleapp
-        displayName: "Android E2E tests"
+        displayName: "Android E2E P0 tests"
+        continueOnError: false
         variables:
           - name: storageID
             value: $[ dependencies.update_sampleapp.outputs['set_slid_vars.androidSLID'] ]        
@@ -112,9 +113,33 @@ stages:
               THREADS: 3
               STORAGE_ID: $(storageID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
-      - job: iOS_e2e_tests
+     - job: android_e2e_tests_non_P0s
+        dependsOn: android_e2e_tests_P0s
+        displayName: "Android E2E Non P0 tests"
+        continueOnError: false
+        variables:
+          - name: storageID
+            value: $[ dependencies.update_sampleapp.outputs['set_slid_vars.androidSLID'] ]        
+        steps:
+          - checkout: self
+          - checkout: MobilePluginsE2ETests
+          - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
+            parameters:
+              DATACENTER: eu
+              DEVICE: "samsung or google"
+              DEVICE_PLATFORM: Android
+              DEVICE_VERSION: 12
+              PLATFORM_TYPE: Mobile
+              PLUGIN: Camera
+              RETRY: 1
+              TEST_TYPE: native
+              THREADS: 3
+              STORAGE_ID: $(storageID)
+              WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
+      - job: iOS_e2e_tests_P0s
         dependsOn: update_sampleapp
-        displayName: "iOS E2E tests"
+        displayName: "iOS E2E P0 tests"
+        continueOnError: false
         variables:
           - name: storageID
             value: $[ dependencies.update_sampleapp.outputs['set_slid_vars.iosSLID'] ]
@@ -133,3 +158,26 @@ stages:
               THREADS: 3
               STORAGE_ID: $(storageID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
+     - job: iOS_e2e_tests_non_P0s
+        dependsOn: iOS_e2e_tests_P0s
+        displayName: "iOS E2E Non P0 tests"
+        continueOnError: false
+        variables:
+          - name: storageID
+            value: $[ dependencies.update_sampleapp.outputs['set_slid_vars.iosSLID'] ]
+        steps:
+          - checkout: self
+          - checkout: MobilePluginsE2ETests
+          - template: build/ci/templates/run-tests.yaml@MobilePluginsE2ETests
+            parameters:
+              DATACENTER: eu
+              DEVICE_PLATFORM: iOS
+              DEVICE_VERSION: 16
+              PLATFORM_TYPE: Mobile
+              PLUGIN: Camera
+              RETRY: 1
+              TEST_TYPE: native
+              THREADS: 3
+              STORAGE_ID: $(storageID)
+              WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
+

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -114,7 +114,7 @@ stages:
               THREADS: 3
               STORAGE_ID: $(storageID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
-     - job: android_e2e_tests_non_P0s
+      - job: android_e2e_tests_non_P0s
         dependsOn: android_e2e_tests_P0s
         displayName: "Android E2E Non P0 tests"
         continueOnError: false
@@ -160,7 +160,7 @@ stages:
               THREADS: 3
               STORAGE_ID: $(storageID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
-     - job: iOS_e2e_tests_non_P0s
+      - job: iOS_e2e_tests_non_P0s
         dependsOn: iOS_e2e_tests_P0s
         displayName: "iOS E2E Non P0 tests"
         continueOnError: false

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -92,7 +92,6 @@ stages:
             displayName: "Set SauceLabs Storage IDs variables"
       - job: android_e2e_tests_P0s
         displayName: "Android E2E P0 tests"
-        dependsOn: update_sampleapp
         continueOnError: false
         variables:
           - name: storageID
@@ -139,7 +138,6 @@ stages:
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
       - job: iOS_e2e_tests_P0s
         displayName: "iOS E2E P0 tests"
-        dependsOn: update_sampleapp
         continueOnError: false
         variables:
           - name: storageID

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -108,6 +108,7 @@ stages:
               DEVICE_VERSION: 12
               PLATFORM_TYPE: Mobile
               PLUGIN: Camera
+              TAGS: '@p0'
               RETRY: 1
               TEST_TYPE: native
               THREADS: 3
@@ -153,6 +154,7 @@ stages:
               DEVICE_VERSION: 16
               PLATFORM_TYPE: Mobile
               PLUGIN: Camera
+              TAGS: '@p0'
               RETRY: 1
               TEST_TYPE: native
               THREADS: 3

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -105,7 +105,7 @@ stages:
               DATACENTER: eu
               DEVICE: "samsung or google"
               DEVICE_PLATFORM: Android
-              DEVICE_VERSION: 12
+              DEVICE_VERSION: 13
               PLATFORM_TYPE: Mobile
               PLUGIN: Camera
               TAGS: '@p0'
@@ -129,7 +129,7 @@ stages:
               DATACENTER: eu
               DEVICE: "samsung or google"
               DEVICE_PLATFORM: Android
-              DEVICE_VERSION: 12
+              DEVICE_VERSION: 13
               PLATFORM_TYPE: Mobile
               PLUGIN: Camera
               RETRY: 1

--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -91,7 +91,6 @@ stages:
             name: set_slid_vars
             displayName: "Set SauceLabs Storage IDs variables"
       - job: android_e2e_tests_P0s
-        dependsOn: update_sampleapp
         displayName: "Android E2E P0 tests"
         continueOnError: false
         variables:
@@ -138,7 +137,6 @@ stages:
               STORAGE_ID: $(storageID)
               WORKING_DIR: $(System.DefaultWorkingDirectory)/MobilePluginsE2ETests
       - job: iOS_e2e_tests_P0s
-        dependsOn: update_sampleapp
         displayName: "iOS E2E P0 tests"
         continueOnError: false
         variables:


### PR DESCRIPTION
<!--
Update the yml file to run firstly the P0 tests for Android & iOS and to fail when tests fail or the publish results task fails. 

Thanks!
-->



### Testing
**Before the changes in this PR** 
https://dev.azure.com/OutSystemsRD/Mobile%20Supported%20Plugins/_build/results?buildId=714933&view=logs&j=1e42a8e3-1f4c-58aa-552e-2ea429935411&t=0e576ff0-815c-5bb3-4d7a-d8594da0507f pipeline is green with tests failing

![Screenshot 2023-05-15 at 10 02 36](https://github.com/OutSystems/cordova-plugin-camera/assets/44206174/092c1174-6b47-47a6-898a-33aafe8f3f44)

**pipeline with this PR:**
https://dev.azure.com/OutSystemsRD/Mobile%20Supported%20Plugins/_build/results?buildId=738913&view=logs&j=e00692a0-a554-521c-976c-8caf982a29cf
![Screenshot 2023-05-15 at 10 14 46](https://github.com/OutSystems/cordova-plugin-camera/assets/44206174/99b801ab-0cad-40e3-acb1-b26bcc93f94d)



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
