### PR TITLE
RMET-2493 ::: Allow edit in Choose From Gallery pictures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 16-05-2023
+Android - Editing photos is now possible when using ChooseFromGallery for single items. (https://outsystemsrd.atlassian.net/browse/RMET-2493)
+
 ### Features
 - [iOS] Select iCloud media on `Choose from Gallery` (https://outsystemsrd.atlassian.net/browse/RMET-2435).
 - [Bridge] Add `allow Edit`to `Choose From Gallery` (https://outsystemsrd.atlassian.net/browse/RMET-2489)

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -16,7 +16,8 @@ apply plugin: 'kotlin-kapt'
 dependencies {
   implementation("com.github.outsystems:oscore-android:1.1.0@aar")
   implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
-  implementation("com.github.outsystems:oscamera-android:1.0.0@aar")
+  //implementation("com.github.outsystems:oscamera-android:1.1.0.0@aar")
+  implementation(project(":GradleProjectA"))
 }
 
 // Defer the definition of the dependencies to the end

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -17,7 +17,6 @@ dependencies {
   implementation("com.github.outsystems:oscore-android:1.1.0@aar")
   implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
   implementation("com.github.outsystems:oscamera-android:1.1.0.0@aar")
-  //implementation(project(":GradleProjectA"))
 }
 
 // Defer the definition of the dependencies to the end

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'kotlin-kapt'
 dependencies {
   implementation("com.github.outsystems:oscore-android:1.1.0@aar")
   implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
-  //implementation("com.github.outsystems:oscamera-android:1.1.0.0@aar")
-  implementation(project(":GradleProjectA"))
+  implementation("com.github.outsystems:oscamera-android:1.1.0.0@aar")
+  //implementation(project(":GradleProjectA"))
 }
 
 // Defer the definition of the dependencies to the end

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -421,10 +421,10 @@ class CameraLauncher : CordovaPlugin() {
 
         try {
             val parameters = args.getJSONObject(0)
-            galleryMediaType = OSCAMRMediaType.IMAGE
+            galleryMediaType = OSCAMRMediaType.fromValue(parameters.getInt(MEDIA_TYPE))
             allowMultipleSelection = parameters.getBoolean(ALLOW_MULTIPLE)
             includeMetadata = parameters.getBoolean(INCLUDE_METADATA)
-            allowEdit = !parameters.getBoolean(ALLOW_EDIT)
+            allowEdit = parameters.getBoolean(ALLOW_EDIT)
         }
         catch(_: Exception) {
             sendError(OSCAMRError.GENERIC_CHOOSE_MULTIMEDIA_ERROR)

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -421,10 +421,10 @@ class CameraLauncher : CordovaPlugin() {
 
         try {
             val parameters = args.getJSONObject(0)
-            galleryMediaType = OSCAMRMediaType.fromValue(parameters.getInt(MEDIA_TYPE))
+            galleryMediaType = OSCAMRMediaType.IMAGE
             allowMultipleSelection = parameters.getBoolean(ALLOW_MULTIPLE)
             includeMetadata = parameters.getBoolean(INCLUDE_METADATA)
-            allowEdit = parameters.getBoolean(ALLOW_EDIT)
+            allowEdit = !parameters.getBoolean(ALLOW_EDIT)
         }
         catch(_: Exception) {
             sendError(OSCAMRError.GENERIC_CHOOSE_MULTIMEDIA_ERROR)
@@ -436,7 +436,7 @@ class CameraLauncher : CordovaPlugin() {
 
             PermissionHelper.requestPermission(
                 this,
-                CHOOSE_FROM_GALLERY_PERMISSION_CODE,
+                OSCAMRController.CHOOSE_FROM_GALLERY_PERMISSION_CODE,
                 Manifest.permission.READ_EXTERNAL_STORAGE
             )
         }
@@ -445,7 +445,7 @@ class CameraLauncher : CordovaPlugin() {
                     || !PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO))) {
             PermissionHelper.requestPermissions(
                 this,
-                CHOOSE_FROM_GALLERY_PERMISSION_CODE,
+                OSCAMRController.CHOOSE_FROM_GALLERY_PERMISSION_CODE,
                 arrayOf(READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)
             )
         }
@@ -463,7 +463,7 @@ class CameraLauncher : CordovaPlugin() {
             this.cordova.activity,
             galleryMediaType,
             allowMultipleSelection,
-            CHOOSE_FROM_GALLERY_REQUEST_CODE
+            OSCAMRController.CHOOSE_FROM_GALLERY_REQUEST_CODE
         )
     }
 
@@ -498,11 +498,18 @@ class CameraLauncher : CordovaPlugin() {
      */
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
 
-        if(requestCode == CHOOSE_FROM_GALLERY_REQUEST_CODE) {
-
+        if(requestCode == OSCAMRController.CHOOSE_FROM_GALLERY_REQUEST_CODE) {
             if(camController == null) {
                 sendError(OSCAMRError.GENERIC_CHOOSE_MULTIMEDIA_ERROR)
                 return
+            }
+
+            if (allowEdit && galleryMediaType == OSCAMRMediaType.IMAGE) {
+                /* This ensures the plugin is called when the result from image edition is returned;
+                When the plugin migrates to the new structure, this call should be
+                made from the library and implemented by cordova plugin, just like in H&F plugin.
+                 */
+                cordova.setActivityResultCallback(this)
             }
 
             CoroutineScope(Dispatchers.Default).launch {
@@ -511,9 +518,25 @@ class CameraLauncher : CordovaPlugin() {
                     resultCode,
                     intent,
                     includeMetadata,
+                    allowEdit,
+                    galleryMediaType,
                     { sendSuccessfulResult(it) },
                     { sendError(it) })
             }
+            return
+        }
+
+        if (requestCode == OSCAMRController.EDIT_FROM_GALLERY_REQUEST_CODE) {
+            CoroutineScope(Dispatchers.Default).launch {
+                camController!!.onChooseFromGalleryEditResult(
+                    cordova.activity,
+                    resultCode,
+                    intent,
+                    includeMetadata,
+                    { sendSuccessfulResult(it) },
+                    { sendError(it) })
+            }
+            return
         }
 
         // Get src and dest types from request code for a Camera Activity
@@ -643,7 +666,7 @@ class CameraLauncher : CordovaPlugin() {
             } else {
                 sendError(OSCAMRError.GET_IMAGE_ERROR)
             }
-        } else if (requestCode == EDIT_RESULT) {
+        } else if (requestCode == OSCAMRController.EDIT_REQUEST_CODE) {
             if (resultCode == Activity.RESULT_OK) {
                 camController?.processResultFromEdit(intent,
                     {
@@ -744,7 +767,7 @@ class CameraLauncher : CordovaPlugin() {
             }
             SAVE_TO_ALBUM_SEC -> callGetImage(srcType, destType, encodingType)
             CAPTURE_VIDEO_SEC -> callCaptureVideo(saveVideoToGallery)
-            CHOOSE_FROM_GALLERY_PERMISSION_CODE -> callChooseFromGallery()
+            OSCAMRController.CHOOSE_FROM_GALLERY_PERMISSION_CODE -> callChooseFromGallery()
         }
     }
 
@@ -877,14 +900,9 @@ class CameraLauncher : CordovaPlugin() {
         private const val READ_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES"
         private const val READ_MEDIA_VIDEO = "android.permission.READ_MEDIA_VIDEO"
 
-        private const val EDIT_RESULT = 7
-
         //for errors
         private const val ERROR_FORMAT_PREFIX = "OS-PLUG-CAMR-"
         protected val permissions = createPermissionArray()
-
-        private const val CHOOSE_FROM_GALLERY_REQUEST_CODE = 869456849
-        private const val CHOOSE_FROM_GALLERY_PERMISSION_CODE = 869454849
 
         private const val STORE = "CameraStore"
         private const val VIDEO_URI = "videoURI"


### PR DESCRIPTION
## Description
- Allows photo edit when user selects a single item from gallery.
- Request codes are now public, available on OSCameraLibrary, so these can be used by bridge. (These were copied on the bridged)

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2493

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [X] Feature (non-breaking change which adds functionality)
- [X] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests
- Tested on Android Studio using the newly created .aar;
- Forced "AllowEdit" to true in code;
- Tested on Android Studio on real device.
- MABS8 build: https://engineering.outsystems.net/MABS/BuildDetail.aspx?BuildId=0eede9549c8e1be77e98a6d77a7cfe80cd211caf&StageId=1
- MABS9 build: https://engineering.outsystems.net/MABS/BuildDetail.aspx?BuildId=4116ca9e32b64f0932395a6b6c133601b53262d0&StageId=1

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
