### PR TITLE
Identify Old and New Version of TakePicture

### DIFF
--- a/www/Camera.js
+++ b/www/Camera.js
@@ -238,7 +238,7 @@ cameraExport.playVideo = function(successCallback, errorCallback, options){
 }
 
 cameraExport.takePicture = function (successCallback, errorCallback, options) {
-    argscheck.checkArgs('fFO', 'Camera.getPicture', arguments);
+    argscheck.checkArgs('fFO', 'Camera.takePicture', arguments);
     options = options || {};
     let getValue = argscheck.getValue;
 

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -254,10 +254,11 @@ cameraExport.takePicture = function (successCallback, errorCallback, options) {
     let saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     let cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
     let includeMetadata = !!options.includeMetadata;
-
+    let latestVersion = !!options.latestVersion;
 
     let args = [{quality, targetWidth, targetHeight, encodingType, allowEdit, correctOrientation, 
-        saveToPhotoAlbum, cameraDirection, destinationType, sourceType, mediaType, includeMetadata}];
+        saveToPhotoAlbum, cameraDirection, destinationType, sourceType, mediaType, includeMetadata,
+        latestVersion}];
 
     exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
     // XXX: commented out


### PR DESCRIPTION
## Description
- Apply the `argscheck.checkArgs` to the correct method.
- Add the new `latestVersion` property to the `takePicture` method argument list. This will allow the native libraries to identify if it's dealing with the latest client action or the deprecated one.

## Context
- https://outsystemsrd.atlassian.net/browse/RMET-2491
- https://outsystemsrd.atlassian.net/browse/RMET-2492

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Checklist
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly

