### PR TITLE
RDSTF-401 added ModelAPI_InternalCode var group

### DIFF
--- a/build/ci/azure-pipeline-test.yml
+++ b/build/ci/azure-pipeline-test.yml
@@ -35,6 +35,7 @@ variables:
   - group: MobileConfigCredentials
   - group: "Saucelabs User Variables"
   - group: "Camera Plugin Variables"
+  - group: "ModelAPI_InternalCode"
 
 stages:
   - stage: Camera_E2E_Tests_Android


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
N/A


### Motivation and Context
Changes to the pipeline templates require a new environment variable, available as a secret in Azure.
https://github.com/OutSystems/MobilePluginsODCPipeline/pull/9

### Description
Since Camera Plugin is now a protected app, we need a special code to be able to open it with Model.API.
This code is passed to the pipeline as an environment variable named ModelAPI_InternalCode.


### Testing
Ran pipeline with both branches, and it passed both steps to update plugin wrapper and refresh sample app references:
https://dev.azure.com/OutSystemsRD/Mobile%20Supported%20Plugins/_build/results?buildId=795565&view=results



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
