### PR TITLE
RMET-2656 - Camera Plugin - Avoid asking for unnecessary permissions for Android >= 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+
+## [Unreleased]
+
+### 03-08-2023
+Android - Avoid asking for unnecessary permissions for Android >= 13. (https://outsystemsrd.atlassian.net/browse/RMET-2656)
+
 ## [4.2.0-OS42]
 
 ### Features

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
   implementation("com.github.outsystems:oscore-android:1.1.0@aar")
   implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
-  implementation("com.github.outsystems:oscamera-android:1.1.0@aar")
+  implementation("com.github.outsystems:oscamera-android:1.1.0.1@aar")
 }
 
 // Defer the definition of the dependencies to the end

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -294,10 +294,7 @@ class CameraLauncher : CordovaPlugin() {
     fun callTakePicture(returnType: Int, encodingType: Int) {
         val saveAlbumPermission = Build.VERSION.SDK_INT < 33 &&
                 PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
-                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) ||
-                Build.VERSION.SDK_INT >= 33 &&
-                PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO) &&
-                PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES)
+                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
         var takePicturePermission = PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)
 
         // CB-10120: The CAMERA permission does not need to be requested unless it is declared
@@ -337,15 +334,9 @@ class CameraLauncher : CordovaPlugin() {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
                 )
             )
-        } else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT == 33) {
-            PermissionHelper.requestPermissions(
-                this,
-                TAKE_PIC_SEC,
-                arrayOf(READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)
-            )
         }
-        // we don't want to ask for this permission from Android 14 onwards
-        else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT > 33) {
+        // we don't want to ask for this permission from Android 13 onwards
+        else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT >= 33) {
             cordova.setActivityResultCallback(this)
             camController?.takePicture(cordova.activity, returnType, encodingType)
         } else {
@@ -372,17 +363,9 @@ class CameraLauncher : CordovaPlugin() {
                 SAVE_TO_ALBUM_SEC,
                 Manifest.permission.READ_EXTERNAL_STORAGE
             )
-        } else if (Build.VERSION.SDK_INT == 33 && (!PermissionHelper.hasPermission(
-                this,
-                READ_MEDIA_IMAGES
-            ) || !PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO))
-        ) {
-            PermissionHelper.requestPermissions(
-                this, SAVE_TO_ALBUM_SEC, arrayOf(
-                    READ_MEDIA_VIDEO, READ_MEDIA_IMAGES
-                )
-            )
-        } else {
+        }
+        // we don't want to ask for this permission from Android 13 onwards
+        else {
             camParameters?.let {
                 cordova.setActivityResultCallback(this)
                 camController?.getImage(this.cordova.activity, srcType, returnType, it)
@@ -404,33 +387,21 @@ class CameraLauncher : CordovaPlugin() {
 
     fun callEditUriImage(editParameters: OSCAMREditParameters) {
 
-        val galleryPermissionNeeded = !((Build.VERSION.SDK_INT < 33 &&
+        val galleryPermissionNeeded = !(Build.VERSION.SDK_INT < 33 &&
                 PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
-                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) ||
-                (Build.VERSION.SDK_INT >= 33 &&
-                        PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO) &&
-                        PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES)))
+                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
 
-        // we don't want to ask for this permission from Android 14 onwards
-        if (galleryPermissionNeeded && Build.VERSION.SDK_INT <= 33) {
-            if (Build.VERSION.SDK_INT < 33) {
-                var permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
-                if (editParameters.saveToGallery) {
-                    permissions += Manifest.permission.WRITE_EXTERNAL_STORAGE
-                }
-                PermissionHelper.requestPermissions(
-                    this,
-                    EDIT_PICTURE_SEC,
-                    permissions
-                )
+        // we don't want to ask for this permission from Android 13 onwards
+        if (galleryPermissionNeeded && Build.VERSION.SDK_INT < 33) {
+            var permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+            if (editParameters.saveToGallery) {
+                permissions += Manifest.permission.WRITE_EXTERNAL_STORAGE
             }
-            else {
-                PermissionHelper.requestPermissions(
-                    this,
-                    EDIT_PICTURE_SEC,
-                    arrayOf(READ_MEDIA_IMAGES)
-                )
-            }
+            PermissionHelper.requestPermissions(
+                this,
+                EDIT_PICTURE_SEC,
+                permissions
+            )
             return
         }
 
@@ -449,12 +420,9 @@ class CameraLauncher : CordovaPlugin() {
 
         val cameraPermissionNeeded = !PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)
 
-        val galleryPermissionNeeded = saveVideoToGallery && !((Build.VERSION.SDK_INT < 33 &&
+        val galleryPermissionNeeded = saveVideoToGallery && !(Build.VERSION.SDK_INT < 33 &&
                 PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
-                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) ||
-                (Build.VERSION.SDK_INT >= 33 &&
-                        PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO) &&
-                        PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES)))
+                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
 
         if (cameraPermissionNeeded && galleryPermissionNeeded) {
             PermissionHelper.requestPermissions(this, CAPTURE_VIDEO_SEC, permissions)
@@ -469,24 +437,16 @@ class CameraLauncher : CordovaPlugin() {
             )
             return
         }
-        else if (galleryPermissionNeeded && Build.VERSION.SDK_INT <= 33) {
-            if (Build.VERSION.SDK_INT < 33) {
-                PermissionHelper.requestPermissions(
-                    this,
-                    CAPTURE_VIDEO_SEC,
-                    arrayOf(
-                        Manifest.permission.READ_EXTERNAL_STORAGE,
-                        Manifest.permission.WRITE_EXTERNAL_STORAGE
-                    )
+        // we don't want to ask for this permission from Android 13 onwards
+        else if (galleryPermissionNeeded && Build.VERSION.SDK_INT < 33) {
+            PermissionHelper.requestPermissions(
+                this,
+                CAPTURE_VIDEO_SEC,
+                arrayOf(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
                 )
-            }
-            else {
-                PermissionHelper.requestPermissions(
-                    this,
-                    CAPTURE_VIDEO_SEC,
-                    arrayOf(READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)
-                )
-            }
+            )
             return
         }
 
@@ -523,16 +483,7 @@ class CameraLauncher : CordovaPlugin() {
                 Manifest.permission.READ_EXTERNAL_STORAGE
             )
         }
-        else if (Build.VERSION.SDK_INT == 33
-            && (!PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES)
-                    || !PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO))) {
-            PermissionHelper.requestPermissions(
-                this,
-                OSCAMRController.CHOOSE_FROM_GALLERY_PERMISSION_CODE,
-                arrayOf(READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)
-            )
-        }
-        // we don't want to ask for this permission from Android 14 onwards
+        // we don't want to ask for this permission from Android 13 onwards
         else {
             callChooseFromGallery()
         }
@@ -859,10 +810,8 @@ class CameraLauncher : CordovaPlugin() {
             if (grantResults[i] == PackageManager.PERMISSION_DENIED && permissions[i] == Manifest.permission.CAMERA) {
                 sendError(OSCAMRError.CAMERA_PERMISSION_DENIED_ERROR)
                 return
-            } else if (grantResults[i] == PackageManager.PERMISSION_DENIED && ((Build.VERSION.SDK_INT < 33
+            } else if (grantResults[i] == PackageManager.PERMISSION_DENIED && (Build.VERSION.SDK_INT < 33
                         && (permissions[i] == Manifest.permission.READ_EXTERNAL_STORAGE || permissions[i] == Manifest.permission.WRITE_EXTERNAL_STORAGE))
-                        || (Build.VERSION.SDK_INT >= 33
-                        && (permissions[i] == READ_MEDIA_IMAGES || permissions[i] == READ_MEDIA_VIDEO)))
             ) {
                 sendError(OSCAMRError.GALLERY_PERMISSION_DENIED_ERROR)
                 return
@@ -1006,10 +955,6 @@ class CameraLauncher : CordovaPlugin() {
         private const val CROP_GALERY = 666
         private const val TIME_FORMAT = "yyyyMMdd_HHmmss"
 
-        //we need literal values because we cannot simply do Manifest.permission.READ_MEDIA_IMAGES, because of the target sdk
-        private const val READ_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES"
-        private const val READ_MEDIA_VIDEO = "android.permission.READ_MEDIA_VIDEO"
-
         //for errors
         private const val ERROR_FORMAT_PREFIX = "OS-PLUG-CAMR-"
         protected val permissions = createPermissionArray()
@@ -1043,14 +988,8 @@ class CameraLauncher : CordovaPlugin() {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
                 )
-            } else if (Build.VERSION.SDK_INT == 33) {
-                arrayOf(
-                    Manifest.permission.CAMERA,
-                    READ_MEDIA_IMAGES,
-                    READ_MEDIA_VIDEO
-                )
             }
-            // we don't want to request READ_MEDIA_IMAGES and READ_MEDIA_VIDEO for Android >= 14
+            // we don't want to request READ_MEDIA_IMAGES and READ_MEDIA_VIDEO for Android >= 13
             else {
                 arrayOf(
                     Manifest.permission.CAMERA

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -337,12 +337,17 @@ class CameraLauncher : CordovaPlugin() {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
                 )
             )
-        } else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT >= 33) {
+        } else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT == 33) {
             PermissionHelper.requestPermissions(
                 this,
                 TAKE_PIC_SEC,
                 arrayOf(READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)
             )
+        }
+        // we don't want to ask for this permission from Android 14 onwards
+        else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT > 33) {
+            cordova.setActivityResultCallback(this)
+            camController?.takePicture(cordova.activity, returnType, encodingType)
         } else {
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, permissions)
         }
@@ -367,7 +372,7 @@ class CameraLauncher : CordovaPlugin() {
                 SAVE_TO_ALBUM_SEC,
                 Manifest.permission.READ_EXTERNAL_STORAGE
             )
-        } else if (Build.VERSION.SDK_INT >= 33 && (!PermissionHelper.hasPermission(
+        } else if (Build.VERSION.SDK_INT == 33 && (!PermissionHelper.hasPermission(
                 this,
                 READ_MEDIA_IMAGES
             ) || !PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO))
@@ -406,7 +411,8 @@ class CameraLauncher : CordovaPlugin() {
                         PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO) &&
                         PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES)))
 
-        if (galleryPermissionNeeded) {
+        // we don't want to ask for this permission from Android 14 onwards
+        if (galleryPermissionNeeded && Build.VERSION.SDK_INT <= 33) {
             if (Build.VERSION.SDK_INT < 33) {
                 var permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
                 if (editParameters.saveToGallery) {
@@ -463,7 +469,7 @@ class CameraLauncher : CordovaPlugin() {
             )
             return
         }
-        else if (galleryPermissionNeeded) {
+        else if (galleryPermissionNeeded && Build.VERSION.SDK_INT <= 33) {
             if (Build.VERSION.SDK_INT < 33) {
                 PermissionHelper.requestPermissions(
                     this,
@@ -517,7 +523,7 @@ class CameraLauncher : CordovaPlugin() {
                 Manifest.permission.READ_EXTERNAL_STORAGE
             )
         }
-        else if (Build.VERSION.SDK_INT >= 33
+        else if (Build.VERSION.SDK_INT == 33
             && (!PermissionHelper.hasPermission(this, READ_MEDIA_IMAGES)
                     || !PermissionHelper.hasPermission(this, READ_MEDIA_VIDEO))) {
             PermissionHelper.requestPermissions(
@@ -526,6 +532,7 @@ class CameraLauncher : CordovaPlugin() {
                 arrayOf(READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)
             )
         }
+        // we don't want to ask for this permission from Android 14 onwards
         else {
             callChooseFromGallery()
         }
@@ -1036,11 +1043,17 @@ class CameraLauncher : CordovaPlugin() {
                     Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
                 )
-            } else {
+            } else if (Build.VERSION.SDK_INT == 33) {
                 arrayOf(
                     Manifest.permission.CAMERA,
                     READ_MEDIA_IMAGES,
                     READ_MEDIA_VIDEO
+                )
+            }
+            // we don't want to request READ_MEDIA_IMAGES and READ_MEDIA_VIDEO for Android >= 14
+            else {
+                arrayOf(
+                    Manifest.permission.CAMERA
                 )
             }
         }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR changes the permission code so that we avoid asking for the unnecessary gallery permissions for Android >= 13.
- For Android >= 13, this permission isn't needed for any plugin feature.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2656

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested on Android 14 device (Pixel 7), using MABS 9 and MABS 8.
- Tested on Android 13 device (Samsung A51), using MABS 9 and MABS 8.
- Tested on Android 12 device (Pixel 3 XL), using MABS 9 and MABS 8.
- 
- O11 MABS 9 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=795e49f5a07f23068945f30a60dae8bdd478d519
- O11 MABS 8.1 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=8843bedf2a5e8b7ad6f4206c84f25d3b131deedd
- ODC MABS 9 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=b6a49e7d9f2624d1e6692703cee1a356a1313682

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
