### PR TITLE
RMET-3812 - Use PhotoPicker API to select media from gallery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### Features
+- (android) Use PhotoPicker to select media from gallery (https://outsystemsrd.atlassian.net/browse/RMET-3812).
+
 ### Fixes
 - (android) Add image resolution and quality when creating its thumbnail (https://outsystemsrd.atlassian.net/browse/RMET-3810).
 

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -8,4 +8,5 @@ repositories {
 
 dependencies {
   implementation("com.github.outsystems:oscamera-android:1.2.7-dev2@aar")
+  implementation 'androidx.activity:activity-ktx:1.9.3'
 }

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -8,4 +8,7 @@ repositories {
 
 dependencies {
   implementation("com.github.outsystems:oscamera-android:1.2.7-dev@aar")
+  //compose
+  implementation 'androidx.activity:activity-compose:1.9.3'
+  implementation(platform('androidx.compose:compose-bom:2024.11.00'))
 }

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.outsystems:oscamera-android:1.2.7-dev2@aar")
+  implementation("com.github.outsystems:oscamera-android:1.2.7-dev3@aar")
   implementation 'androidx.activity:activity-ktx:1.9.3'
 }

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.outsystems:oscamera-android:1.2.7-dev@aar")
+  implementation("com.github.outsystems:oscamera-android:1.2.7-dev2@aar")
   //compose
   implementation 'androidx.activity:activity-compose:1.9.3'
   implementation(platform('androidx.compose:compose-bom:2024.11.00'))

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -7,5 +7,5 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.outsystems:oscamera-android:1.2.6-rmet3810-2@aar")
+  implementation("com.github.outsystems:oscamera-android:1.2.7-dev@aar")
 }

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -8,7 +8,4 @@ repositories {
 
 dependencies {
   implementation("com.github.outsystems:oscamera-android:1.2.7-dev2@aar")
-  //compose
-  implementation 'androidx.activity:activity-compose:1.9.3'
-  implementation(platform('androidx.compose:compose-bom:2024.11.00'))
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates dependency to `OSCameraLib-Android` to bring the update in https://github.com/OutSystems/OSCameraLib-Android/pull/49.
- It also adds the `androidx.activity:activity-ktx` Gradle dependency. This is necessary for the `chooseFromGallery` feature to work on Android 12 devices. Without them, the photo picker isn't presented to the user to select media, it is automatically cancelled.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3812

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested with MABS 11 and MABS 10 on Android 15, 14, 13, 12, 11, 10, and 9.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
