### PR TITLE
RMET-3875 - Fix issue in permission request for `EditURIPicture` and remove unnecessary permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ The changes documented here do not include those from the original repository.
 ### Fixes
 - (android) Add image resolution and quality when creating its thumbnail (https://outsystemsrd.atlassian.net/browse/RMET-3810).
 - (android) Fixes an issue in the permission request in the `callEditUriImage` function, where in some cases the permission kept being requested. (https://outsystemsrd.atlassian.net/browse/RMET-3875).
-- (android) Removes an unnecessary permission request in the `callChooseFromGalleryWithPermissions` function, since no permissions are actually necessary to pick photos from the gallery, even for Android < 13. (https://outsystemsrd.atlassian.net/browse/RMET-3875).
 - (android) Removes `READ_MEDIA_IMAGE` and `READ_MEDIA_VIDEO` permissions from the AndroidManifest.xml file of the resulting app, since these are never requested by the plugin, so there's no point in having them in the manifest file. (https://outsystemsrd.atlassian.net/browse/RMET-3875).
 
 ## 4.2.0-OS51

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## [Unreleased]
+## 4.2.0-OS52
 
 ### Features
 - (android) Use PhotoPicker to select media from gallery (https://outsystemsrd.atlassian.net/browse/RMET-3812).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The changes documented here do not include those from the original repository.
 
 ### Fixes
 - (android) Add image resolution and quality when creating its thumbnail (https://outsystemsrd.atlassian.net/browse/RMET-3810).
+- (android) Fixes an issue in the permission request in the `callEditUriImage` function, where in some cases the permission kept being requested. (https://outsystemsrd.atlassian.net/browse/RMET-3875).
+- (android) Removes an unnecessary permission request in the `callChooseFromGalleryWithPermissions` function, since no permissions are actually necessary to pick photos from the gallery, even for Android < 13. (https://outsystemsrd.atlassian.net/browse/RMET-3875).
+- (android) Removes `READ_MEDIA_IMAGE` and `READ_MEDIA_VIDEO` permissions from the AndroidManifest.xml file of the resulting app, since these are never requested by the plugin, so there's no point in having them in the manifest file. (https://outsystemsrd.atlassian.net/browse/RMET-3875).
 
 ## 4.2.0-OS51
 

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.outsystems:oscamera-android:1.2.7-dev6@aar")
+  implementation("com.github.outsystems:oscamera-android:1.3.0@aar")
   implementation 'androidx.activity:activity-ktx:1.9.3'
 }

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.outsystems:oscamera-android:1.3.0@aar")
+  implementation("com.github.outsystems:oscamera-android:1.2.7-dev6@aar")
   implementation 'androidx.activity:activity-ktx:1.9.3'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.2.0-OS51",
+  "version": "4.2.0-OS52",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="4.2.0-OS51">
+    version="4.2.0-OS52">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -64,8 +64,6 @@
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-            <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
             <uses-permission android:name="android.permission.CAMERA" />
         </config-file>
 

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -383,9 +383,9 @@ class CameraLauncher : CordovaPlugin() {
 
     fun callEditUriImage(editParameters: OSCAMREditParameters) {
 
-        val galleryPermissionNeeded = !(Build.VERSION.SDK_INT < 33 &&
-                PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
-                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
+        val galleryPermissionNeeded = Build.VERSION.SDK_INT < 33 &&
+                (!PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) ||
+                        (editParameters.saveToGallery && !PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)))
 
         // we don't want to ask for this permission from Android 13 onwards
         if (galleryPermissionNeeded && Build.VERSION.SDK_INT < 33) {

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -469,20 +469,8 @@ class CameraLauncher : CordovaPlugin() {
             sendError(OSCAMRError.GENERIC_CHOOSE_MULTIMEDIA_ERROR)
             return
         }
-
-        if (Build.VERSION.SDK_INT < 33
-            && !PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
-
-            PermissionHelper.requestPermission(
-                this,
-                CHOOSE_FROM_GALLERY_PERMISSION_CODE,
-                Manifest.permission.READ_EXTERNAL_STORAGE
-            )
-        }
-        // we don't want to ask for this permission from Android 13 onwards
-        else {
-            callChooseFromGallery()
-        }
+        
+        callChooseFromGallery()
     }
 
     /**

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -382,6 +382,25 @@ class CameraLauncher : CordovaPlugin() {
     }
 
     fun callEditUriImage(editParameters: OSCAMREditParameters) {
+
+        val galleryPermissionNeeded = Build.VERSION.SDK_INT < 33 &&
+                (!PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) ||
+                        (editParameters.saveToGallery && !PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)))
+
+        // we don't want to ask for this permission from Android 13 onwards
+        if (galleryPermissionNeeded && Build.VERSION.SDK_INT < 33) {
+            var permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+            if (editParameters.saveToGallery) {
+                permissions += Manifest.permission.WRITE_EXTERNAL_STORAGE
+            }
+            PermissionHelper.requestPermissions(
+                this,
+                EDIT_PICTURE_SEC,
+                permissions
+            )
+            return
+        }
+
         if (editParameters.editURI.isNullOrEmpty()) {
             sendError(OSCAMRError.EDIT_PICTURE_EMPTY_URI_ERROR)
             return

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -469,8 +469,20 @@ class CameraLauncher : CordovaPlugin() {
             sendError(OSCAMRError.GENERIC_CHOOSE_MULTIMEDIA_ERROR)
             return
         }
-        
-        callChooseFromGallery()
+
+        if (Build.VERSION.SDK_INT < 33
+            && !PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
+
+            PermissionHelper.requestPermission(
+                this,
+                CHOOSE_FROM_GALLERY_PERMISSION_CODE,
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            )
+        }
+        // we don't want to ask for this permission from Android 13 onwards
+        else {
+            callChooseFromGallery()
+        }
     }
 
     /**

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -382,25 +382,6 @@ class CameraLauncher : CordovaPlugin() {
     }
 
     fun callEditUriImage(editParameters: OSCAMREditParameters) {
-
-        val galleryPermissionNeeded = Build.VERSION.SDK_INT < 33 &&
-                (!PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) ||
-                        (editParameters.saveToGallery && !PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)))
-
-        // we don't want to ask for this permission from Android 13 onwards
-        if (galleryPermissionNeeded && Build.VERSION.SDK_INT < 33) {
-            var permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
-            if (editParameters.saveToGallery) {
-                permissions += Manifest.permission.WRITE_EXTERNAL_STORAGE
-            }
-            PermissionHelper.requestPermissions(
-                this,
-                EDIT_PICTURE_SEC,
-                permissions
-            )
-            return
-        }
-
         if (editParameters.editURI.isNullOrEmpty()) {
             sendError(OSCAMRError.EDIT_PICTURE_EMPTY_URI_ERROR)
             return


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Fixes an issue in the permission request in the `callEditUriImage` function, where in some cases the permission kept being requested.
- Removes `READ_MEDIA_IMAGE` and `READ_MEDIA_VIDEO` permissions from the AndroidManifest.xml file of the resulting app, since these are never requested by the plugin, so there's no point in having them in the manifest file.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3875

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested on Android 15, 14, 13, 12, 11, 10 and 9.

MABS 11 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=7b48b872999002187f70787e92a74b9822616dc3&stg=dev

MABS 10 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=bc959d4b80007a634e3c3d728f2d7b936096e27e&stg=dev

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
