### PR TITLE
Fix ::: RMET-3806 ::: Checking camera permission in Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## Unreleased
+
+### Fixes
+- (android) Only request camera permission for photo and video if declared (https://outsystemsrd.atlassian.net/browse/RMET-3806)
+
 ## 4.2.0-OS52
 
 ### Features

--- a/plugin.xml
+++ b/plugin.xml
@@ -64,7 +64,6 @@
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.CAMERA" />
         </config-file>
 
         <edit-config target="AndroidManifest.xml" parent="application">


### PR DESCRIPTION
## Description

Camera permission is only required [if app declares it](https://developer.android.com/reference/android/provider/MediaStore#ACTION_VIDEO_CAPTURE).

Applying that same logic for both `takePicture` and `captureVideo` in Android, and this plugin no longer needs to declare the permission in the manifest.

## Context

- https://outsystemsrd.atlassian.net/browse/RMET-3806

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Test Ticket Sample App in Android versions 10-15, [with MABS 11 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=5e890e53e3e2dad1af276e17fb76eb6e3c3da0b6&stg=dev) (MABS 10 build declares the permissions in manifest), and confirm that no Camera permission request is done, and the app still works as usual.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
