### PR TITLE
RMET-3930 - Review external storage permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## Unreleased
+## 4.2.0-OS53
 
 ### Fixes
 - (android) Only request external storage permissions in `TakePicture` if `saveToGallery` is true (https://outsystemsrd.atlassian.net/browse/RMET-3930)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The changes documented here do not include those from the original repository.
 ## Unreleased
 
 ### Fixes
+- (android) Only request external storage permissions in `TakePicture` if `saveToGallery` is true (https://outsystemsrd.atlassian.net/browse/RMET-3930)
+- (android) Only request external storage permissions for Android <= 10 (https://outsystemsrd.atlassian.net/browse/RMET-3930)
 - (android) Only request camera permission for photo and video if declared (https://outsystemsrd.atlassian.net/browse/RMET-3806)
 
 ## 4.2.0-OS52

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.outsystems:oscamera-android:1.3.1-dev4@aar")
+  implementation("com.github.outsystems:oscamera-android:1.3.2@aar")
   implementation 'androidx.activity:activity-ktx:1.9.3'
 }

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.outsystems:oscamera-android:1.3.0@aar")
+  implementation("com.github.outsystems:oscamera-android:1.3.1@aar")
   implementation 'androidx.activity:activity-ktx:1.9.3'
 }

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -7,6 +7,6 @@ repositories {
 }
 
 dependencies {
-  implementation("com.github.outsystems:oscamera-android:1.3.1@aar")
+  implementation("com.github.outsystems:oscamera-android:1.3.1-dev4@aar")
   implementation 'androidx.activity:activity-ktx:1.9.3'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.2.0-OS52",
+  "version": "4.2.0-OS53",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="4.2.0-OS52">
+    version="4.2.0-OS53">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -62,8 +62,8 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
         </config-file>
 
         <edit-config target="AndroidManifest.xml" parent="application">

--- a/plugin.xml
+++ b/plugin.xml
@@ -62,8 +62,8 @@
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
-            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
         </config-file>
 
         <edit-config target="AndroidManifest.xml" parent="application">

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -269,18 +269,24 @@ class CameraLauncher : CordovaPlugin() {
      * @param encodingType           Compression quality hint (0-100: 0=low quality & high compression, 100=compress of max quality)
      */
     fun callTakePicture(returnType: Int, encodingType: Int) {
-        val saveAlbumPermission = Build.VERSION.SDK_INT < 33 &&
-                PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
-                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+
+        val saveAlbumPermission = Build.VERSION.SDK_INT >= 33 || !saveToPhotoAlbum ||
+                (PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
+                PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
+
         val takePicturePermission = PermissionHelper.hasPermission(this, Manifest.permission.CAMERA) ||
                 !hasCameraPermissionDeclared()
 
-        if (takePicturePermission && saveAlbumPermission) {
+        if (takePicturePermission && saveAlbumPermission) { // no permissions need to be requested
             cordova.setActivityResultCallback(this)
             camController?.takePicture(cordova.activity, returnType, encodingType)
-        } else if (saveAlbumPermission && !takePicturePermission) {
+        }
+
+        else if (saveAlbumPermission) { // we need to request camera permissions
             PermissionHelper.requestPermission(this, TAKE_PIC_SEC, Manifest.permission.CAMERA)
-        } else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT < 33) {
+        }
+
+        else if (takePicturePermission) { // we need to request storage permissions
             PermissionHelper.requestPermissions(
                 this,
                 TAKE_PIC_SEC,
@@ -290,11 +296,8 @@ class CameraLauncher : CordovaPlugin() {
                 )
             )
         }
-        // we don't want to ask for this permission from Android 13 onwards
-        else if (!saveAlbumPermission && takePicturePermission && Build.VERSION.SDK_INT >= 33) {
-            cordova.setActivityResultCallback(this)
-            camController?.takePicture(cordova.activity, returnType, encodingType)
-        } else {
+
+        else { // we need to request both permissions
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, permissions)
         }
     }

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -312,7 +312,7 @@ class CameraLauncher : CordovaPlugin() {
      */
     fun callGetImage(srcType: Int, returnType: Int, encodingType: Int) {
 
-        if (Build.VERSION.SDK_INT < 33 && !PermissionHelper.hasPermission(
+        if (Build.VERSION.SDK_INT < 30 && !PermissionHelper.hasPermission(
                 this,
                 Manifest.permission.READ_EXTERNAL_STORAGE
             )

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -281,13 +281,9 @@ class CameraLauncher : CordovaPlugin() {
         if (takePicturePermission && saveAlbumPermission) { // no permissions need to be requested
             cordova.setActivityResultCallback(this)
             camController?.takePicture(cordova.activity, returnType, encodingType)
-        }
-
-        else if (saveAlbumPermission) { // we need to request camera permissions
+        } else if (saveAlbumPermission) { // we need to request camera permissions
             PermissionHelper.requestPermission(this, TAKE_PIC_SEC, Manifest.permission.CAMERA)
-        }
-
-        else if (takePicturePermission) { // we need to request storage permissions
+        } else if (takePicturePermission) { // we need to request storage permissions
             PermissionHelper.requestPermissions(
                 this,
                 TAKE_PIC_SEC,
@@ -296,9 +292,7 @@ class CameraLauncher : CordovaPlugin() {
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
                 )
             )
-        }
-
-        else { // we need to request both permissions
+        } else { // we need to request both permissions
             PermissionHelper.requestPermissions(this, TAKE_PIC_SEC, permissions)
         }
     }

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -379,8 +379,8 @@ class CameraLauncher : CordovaPlugin() {
         val cameraPermissionNeeded = !PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)
                 && hasCameraPermissionDeclared()
 
-        val galleryPermissionNeeded = saveVideoToGallery && !(Build.VERSION.SDK_INT < 33 &&
-                PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
+        val galleryPermissionNeeded = Build.VERSION.SDK_INT < 33 && saveVideoToGallery &&
+                !(PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
                 PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
 
         if (cameraPermissionNeeded && galleryPermissionNeeded) {
@@ -396,8 +396,8 @@ class CameraLauncher : CordovaPlugin() {
             )
             return
         }
-        // we don't want to ask for this permission from Android 13 onwards
-        else if (galleryPermissionNeeded && Build.VERSION.SDK_INT < 33) {
+
+        else if (galleryPermissionNeeded) {
             PermissionHelper.requestPermissions(
                 this,
                 CAPTURE_VIDEO_SEC,

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -270,7 +270,7 @@ class CameraLauncher : CordovaPlugin() {
      */
     fun callTakePicture(returnType: Int, encodingType: Int) {
 
-        val saveAlbumPermission = Build.VERSION.SDK_INT >= 33 || !saveToPhotoAlbum ||
+        val saveAlbumPermission = Build.VERSION.SDK_INT >= 30 || !saveToPhotoAlbum ||
                 (PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
                 PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
 
@@ -379,7 +379,7 @@ class CameraLauncher : CordovaPlugin() {
         val cameraPermissionNeeded = !PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)
                 && hasCameraPermissionDeclared()
 
-        val galleryPermissionNeeded = Build.VERSION.SDK_INT < 33 && saveVideoToGallery &&
+        val galleryPermissionNeeded = Build.VERSION.SDK_INT < 30 && saveVideoToGallery &&
                 !(PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
                 PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
 

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -312,6 +312,7 @@ class CameraLauncher : CordovaPlugin() {
      */
     fun callGetImage(srcType: Int, returnType: Int, encodingType: Int) {
 
+        // we don't want to ask for this permission from Android 11 onwards
         if (Build.VERSION.SDK_INT < 30 && !PermissionHelper.hasPermission(
                 this,
                 Manifest.permission.READ_EXTERNAL_STORAGE
@@ -435,6 +436,7 @@ class CameraLauncher : CordovaPlugin() {
             return
         }
 
+        // we don't want to ask for this permission from Android 11 onwards
         if (Build.VERSION.SDK_INT < 30
             && !PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
 
@@ -444,7 +446,6 @@ class CameraLauncher : CordovaPlugin() {
                 Manifest.permission.READ_EXTERNAL_STORAGE
             )
         }
-        // we don't want to ask for this permission from Android 13 onwards
         else {
             callChooseFromGallery()
         }

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -270,6 +270,7 @@ class CameraLauncher : CordovaPlugin() {
      */
     fun callTakePicture(returnType: Int, encodingType: Int) {
 
+        // we don't want to ask for these permissions from Android 11 onwards
         val saveAlbumPermission = Build.VERSION.SDK_INT >= 30 || !saveToPhotoAlbum ||
                 (PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
                 PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
@@ -379,6 +380,7 @@ class CameraLauncher : CordovaPlugin() {
         val cameraPermissionNeeded = !PermissionHelper.hasPermission(this, Manifest.permission.CAMERA)
                 && hasCameraPermissionDeclared()
 
+        // we don't want to ask for these permissions from Android 11 onwards
         val galleryPermissionNeeded = Build.VERSION.SDK_INT < 30 && saveVideoToGallery &&
                 !(PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) &&
                 PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE))
@@ -433,7 +435,7 @@ class CameraLauncher : CordovaPlugin() {
             return
         }
 
-        if (Build.VERSION.SDK_INT < 33
+        if (Build.VERSION.SDK_INT < 30
             && !PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)) {
 
             PermissionHelper.requestPermission(

--- a/src/android/CameraLauncher.kt
+++ b/src/android/CameraLauncher.kt
@@ -345,12 +345,12 @@ class CameraLauncher : CordovaPlugin() {
 
     fun callEditUriImage(editParameters: OSCAMREditParameters) {
 
-        val galleryPermissionNeeded = Build.VERSION.SDK_INT < 33 &&
+        // we don't want to ask for these permissions from Android 11 onwards
+        val galleryPermissionNeeded = Build.VERSION.SDK_INT < 30 &&
                 (!PermissionHelper.hasPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) ||
                         (editParameters.saveToGallery && !PermissionHelper.hasPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)))
 
-        // we don't want to ask for this permission from Android 13 onwards
-        if (galleryPermissionNeeded && Build.VERSION.SDK_INT < 33) {
+        if (galleryPermissionNeeded) {
             var permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
             if (editParameters.saveToGallery) {
                 permissions += Manifest.permission.WRITE_EXTERNAL_STORAGE


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Changes `TakePicture` to only request external storage permissions (`READ_EXTERNAL_STORAGE` and `WRITE_EXTERNAL_STORAGE`) if `saveToGallery` is `true`
- Changes `TakePicture`, `ChooseFromGallery`, `GetImage`, `RecordVideo`, and `EditURIPicture` to only request external storage permissions for Android <= 10. For Android >= 11, these permissions do not need to be requested because we're either using the [PhotoPicker API](https://developer.android.com/training/data-storage/shared/photopicker) or intents when selecting from the gallery, and we're using the [MediaStore](https://developer.android.com/training/data-storage/shared/media) when saving images and videos to the gallery.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-3930

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

[MABS 10 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=37d615603208566ffbccb79c91c848e377f0bc4d&stg=dev)

[MABS 11 build](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=4bbadf4f1ec8d146439cd1a759aab214241ffaed&stg=dev)

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
