### PR TITLE
RMET-4037 ::: iOS ::: Remove `cordova-plugin-add-swift-support` Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Chores
+- (ios) Replace `cordova-plugin-add-swift-support` plugin with the `SwiftVersion` preference (https://outsystemsrd.atlassian.net/browse/RMET-4037).
+
 ## 4.2.0-OS53
 
 ### Fixes

--- a/plugin.xml
+++ b/plugin.xml
@@ -116,9 +116,8 @@
              <feature name="Camera">
                  <param name="ios-package" value="OSCamera" />
              </feature>
+             <preference name="SwiftVersion" value="5" />
          </config-file>
-         
-         <dependency id="cordova-plugin-add-swift-support" url="https://github.com/OutSystems/cordova-plugin-add-swift-support.git#2.0.3-OS1"/>
 
          <preference name="CAMERA_USAGE_DESCRIPTION" default=" " />
          <config-file target="*-Info.plist" parent="NSCameraUsageDescription">


### PR DESCRIPTION
## Description
The only thing the plugin needs is the `SwiftVersion`. This is included directly on `plugin.xml`.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-4037

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
