### PR TITLE
RMET-4294 :: Missing GSON dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 4.2.0-OS57
+
+### Fixes
+- (android) Add missing gson gradle dependency.
+
 ## 4.2.0-OS56
 
 ### Fixes

--- a/libs/android/build.gradle
+++ b/libs/android/build.gradle
@@ -10,4 +10,5 @@ dependencies {
   implementation 'com.github.outsystems:oscamera-android:1.3.3@aar'
   implementation 'androidx.activity:activity-ktx:1.9.3'
   implementation 'androidx.exifinterface:exifinterface:1.3.6'
+  implementation 'com.google.code.gson:gson:2.10.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.2.0-OS56",
+  "version": "4.2.0-OS57",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="4.2.0-OS56">
+    version="4.2.0-OS57">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>


### PR DESCRIPTION
## Description

Recent Capacitor OutSystems builds can fail with missing GSON dependency, which was being included in another, but that has since changed.

Update this plugin to declare the GSON dependency in `build.gradle`, since it is used by this plugin in Android.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-4294

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Use Camera Sample App on ODC.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
