### PR TITLE
RMET-4356 :: Fix Get Picture action input parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 4.2.0-OS58
+
+### Fixes
+- (ios) Fix input parameters for getPicture Cordova action.
+
 ## 4.2.0-OS57
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.2.0-OS57",
+  "version": "4.2.0-OS58",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="4.2.0-OS57">
+    version="4.2.0-OS58">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>

--- a/www/Camera.js
+++ b/www/Camera.js
@@ -141,16 +141,22 @@ cameraExport.getPicture = function (successCallback, errorCallback, options) {
     let destinationType = getValue(options.destinationType, Camera.DestinationType.FILE_URI);
     let targetWidth = getValue(options.targetWidth, -1);
     let targetHeight = getValue(options.targetHeight, -1);
+    if (targetWidth <= 0 || targetHeight <= 0) {
+        targetWidth = null
+        targetHeight = null
+    }
     let encodingType = getValue(options.encodingType, Camera.EncodingType.JPEG);
     let mediaType = getValue(options.mediaType, Camera.MediaType.PICTURE);
     let allowEdit = !!options.allowEdit;
     let correctOrientation = !!options.correctOrientation;
     let saveToPhotoAlbum = !!options.saveToPhotoAlbum;
     let cameraDirection = getValue(options.cameraDirection, Camera.Direction.BACK);
-
+    let includeMetadata = false
+    let latestVersion = false
 
     let args = [{quality, targetWidth, targetHeight, encodingType, allowEdit, correctOrientation, 
-        saveToPhotoAlbum, cameraDirection, destinationType, sourceType, mediaType}];
+        saveToPhotoAlbum, cameraDirection, destinationType, sourceType, mediaType, 
+        includeMetadata, latestVersion}];
 
     exec(successCallback, errorCallback, 'Camera', 'takePicture', args);
     // XXX: commented out


### PR DESCRIPTION
## Description

In iOS, the `takePicture` native cordova method expects all parameters to be mandatory, which is fine for the cordova `takePicture` javascript method, but not for `getPicture` (used by deprecated actions in OutSystems). Also, iOS throws an error if width or heigh are inferior or equal to 0 (which can be the default value from OutSystems)

This PR makes sure those parameters are sent with the correct default values on JavaScript.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-4356

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [x] JavaScript

## Tests

You can use the Ticket App on O11 to test that the original issue (highlighted in JIRA ticket) is now fixed.

I tested Android and PWA and both of those work.


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
