### PR TITLE
fix(ios): properly add PHPhotoLibraryPreventAutomaticLimitedAccessAlert to .plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 4.2.0-OS60
+
+- (ios) Fix - properly add PHPhotoLibraryPreventAutomaticLimitedAccessAlert to .plist (https://outsystemsrd.atlassian.net/browse/RMET-4503)
+
 ## 4.2.0-OS59
 
 - Feature: Enable predictive back navigation animation on activity used for `editImage` for Android 13+ (https://outsystemsrd.atlassian.net/browse/RMET-4336)

--- a/build-actions/cameraAddiOSKey.yaml
+++ b/build-actions/cameraAddiOSKey.yaml
@@ -1,0 +1,6 @@
+platforms:
+  ios:
+    plist:
+      - replace: true
+        entries:
+          - PHPhotoLibraryPreventAutomaticLimitedAccessAlert: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-camera",
-  "version": "4.2.0-OS59",
+  "version": "4.2.0-OS60",
   "description": "Cordova Camera Plugin",
   "types": "./types/index.d.ts",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-camera"
-    version="4.2.0-OS59">
+    version="4.2.0-OS60">
     <name>Camera</name>
     <description>Cordova Camera Plugin</description>
     <license>Apache 2.0</license>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds build action to properly add `PHPhotoLibraryPreventAutomaticLimitedAccessAlert` key to plist for Capacitor builds.
For Cordova builds, this is done through the `plugin.xml` file in https://github.com/OutSystems/cordova-plugin-camera/blob/ce3faee74c9f7deda236408a545b6f913d6e0eb1/plugin.xml#L142

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4503

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS 12 build done in our ODC tenant. To validate that the build action ran properly, look for the `PHPhotoLibraryPreventAutomaticLimitedAccessAlert` key in the app's .plist file.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
